### PR TITLE
Test maquina de estados y prescription repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "node src",
     "test": "jest --verbose",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "test:verbose": "jest --verbose"
   },
   "keywords": [],
   "author": "",

--- a/src/codes/entities-codes.js
+++ b/src/codes/entities-codes.js
@@ -1,0 +1,22 @@
+const codes = {
+    PRESCRIPTION: {
+        name: 'prescription',
+        fields: {
+            issuedDate: 'issuedDate',
+            soldDate: 'soldDate',
+            auditedDate: 'auditedDate',
+            prolongedTreatment: 'prolongedTreatment',
+            diagnosis: 'diagnosis',
+            ttl: 'ttl',
+            institution: 'institution',
+            affiliate: 'affiliate',
+            doctor: 'doctor',
+            medicalInsurance: 'medicalInsurance',
+            status: 'status',
+            norm: 'norm',
+            items: 'items'
+        }
+    }
+}
+
+module.exports = {codes}

--- a/src/domain/prescription.js
+++ b/src/domain/prescription.js
@@ -68,7 +68,6 @@ class Prescription {
         return moment.isMoment(this.auditedDate) ? this.auditedDate.format(formats.dateTimeFormat) : this.auditedDate
     }
 
-    //TODO: Ver que el json que deberia devolver sea en snake_case
     toJson(){
         return JSON.stringify({
             id: this.id,
@@ -88,7 +87,6 @@ class Prescription {
         })
     }
 
-    //TODO: Ver que el json que recibe deberia ser en snake_case
     static fromJson(json = '{}'){
         let object = typeof json === 'object' ? json : JSON.parse(json)
         const prescription = new Prescription()
@@ -114,6 +112,10 @@ class Prescription {
             return Prescription.fromJson(object)
         }
         return object 
+    }
+
+    clone(){
+        return Prescription.fromJson(this.toJson())
     }
 }
 

--- a/src/domain/prescription.js
+++ b/src/domain/prescription.js
@@ -68,6 +68,7 @@ class Prescription {
         return moment.isMoment(this.auditedDate) ? this.auditedDate.format(formats.dateTimeFormat) : this.auditedDate
     }
 
+    //TODO: Ver que el json que deberia devolver sea en snake_case
     toJson(){
         return JSON.stringify({
             id: this.id,
@@ -87,6 +88,7 @@ class Prescription {
         })
     }
 
+    //TODO: Ver que el json que recibe deberia ser en snake_case
     static fromJson(json = '{}'){
         let object = typeof json === 'object' ? json : JSON.parse(json)
         const prescription = new Prescription()

--- a/src/repositories/prescriptions-repository.js
+++ b/src/repositories/prescriptions-repository.js
@@ -1,5 +1,5 @@
 const {Prescription} = require('../domain/prescription')
-const {newNotFoundError, newEntityAllreadyCreated} = require('../utils/errors')
+const {newNotFoundError, newEntityAlreadyCreated} = require('../utils/errors')
 
 class PrescriptionRepository {
     constructor(){
@@ -17,7 +17,7 @@ class PrescriptionRepository {
         return new Promise((resolve, reject) => {
             const prescription = Prescription.fromObject(_prescription)
             if (prescription.id){
-                return reject(newEntityAllreadyCreated('Prescription allready created'))
+                return reject(newEntityAlreadyCreated('Prescription allready created'))
             }
             prescription.id = Math.floor(Math.random() * 10000)
             this.prescriptions.push(prescription)

--- a/src/repositories/prescriptions-repository.js
+++ b/src/repositories/prescriptions-repository.js
@@ -1,4 +1,5 @@
 const {Prescription} = require('../domain/prescription')
+const {newNotFoundError, newEntityAllreadyCreated} = require('../utils/errors')
 
 class PrescriptionRepository {
     constructor(){
@@ -16,9 +17,9 @@ class PrescriptionRepository {
         return new Promise((resolve, reject) => {
             const prescription = Prescription.fromObject(_prescription)
             if (prescription.id){
-                return reject({error: 'Prescription allready created'})
+                return reject(newEntityAllreadyCreated('Prescription allready created'))
             }
-            prescription.id = Math.floor(Math.random() * 1000)
+            prescription.id = Math.floor(Math.random() * 10000)
             this.prescriptions.push(prescription)
             return resolve(prescription)
         })
@@ -27,7 +28,15 @@ class PrescriptionRepository {
     update(_prescription){
         return new Promise((resolve, reject) => {
             const prescription = Prescription.fromObject(_prescription)
-            return resolve(prescription)
+            if (!prescription.id || !this.prescriptions.some((pres) => {return prescription.id === pres.id})){
+                return reject(newNotFoundError('Prescription not found'))
+            }
+            this.prescriptions = this.prescriptions.filter((pres) => {
+                return pres.id !== prescription.id
+            })
+            const newPrescription = Prescription.fromJson(prescription.toJson())
+            this.prescriptions.push(newPrescription)
+            return resolve(newPrescription)
         })
     }
 

--- a/src/repositories/prescriptions-repository.js
+++ b/src/repositories/prescriptions-repository.js
@@ -5,6 +5,13 @@ class PrescriptionRepository {
         this.prescriptions = []
     }
 
+    reset(){
+        return new Promise((resolve, reject) => {
+            this.prescriptions = []
+            return resolve()
+        })
+    }
+
     create(_prescription){
         return new Promise((resolve, reject) => {
             const prescription = Prescription.fromObject(_prescription)
@@ -21,6 +28,12 @@ class PrescriptionRepository {
         return new Promise((resolve, reject) => {
             const prescription = Prescription.fromObject(_prescription)
             return resolve(prescription)
+        })
+    }
+
+    count(){
+        return new Promise((resolve, reject) => {
+            return resolve(this.prescriptions.length)
         })
     }
 

--- a/src/state-machine/state.js
+++ b/src/state-machine/state.js
@@ -123,7 +123,7 @@ const PARTIALLY_RECEIVED = {
 }
 const INCOMPLETE = {
     status: 'INCOMPLETA',
-    validate, validator,
+    validate: validator,
     getStatusError: (prescription) => {
         return getDiferentValueError(prescription.status, PARTIALLY_RECEIVED.status, 'status')
     },
@@ -135,7 +135,7 @@ const INCOMPLETE = {
 }
 const AUDITED = {
     status: 'AUDITADA',
-    validate, validator,
+    validate: validator,
     getStatusError: (prescription) => {
         return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], 'status')
     },
@@ -153,7 +153,7 @@ const AUDITED = {
 }
 const REJECTED = {
     status: 'RECHAZADA',
-    validate, validator,
+    validate: validator,
     getStatusError: (prescription) => {
         return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], 'status')
     },
@@ -171,7 +171,7 @@ const REJECTED = {
 }
 const PARTIALLY_REJECTED = {
     status: 'PARCIALMENTE_RECHAZADA',
-    validate, validator,
+    validate: validator,
     getStatusError: (prescription) => {
         return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], 'status')
     },

--- a/src/state-machine/state.js
+++ b/src/state-machine/state.js
@@ -1,10 +1,13 @@
-const {newNullOrEmptyError, newInvalidValueError, generateFieldCause} = require('../utils/errors')
-const {checkArrayNotEmpty, checkNotNull, checkDiferentValueError, checkValueNotInListError} = require('../utils/errors')
+const {newNullOrEmptyError, generateFieldCause} = require('../utils/errors')
+const {getArrayNotEmptyError, getNotNullError, getDiferentValueError, getValueNotInListError} = require('../utils/errors')
 const {codes} = require('../codes/entities-codes')
+
+const {name: prescriptionEntity} = codes.PRESCRIPTION
+const {fields: prescriptionFields} = codes.PRESCRIPTION
 
 const validator = function(prescription){
     if (!prescription){
-        throw [newNullOrEmptyError('prescription cant be null or empty', generateFieldCause(codes.PRESCRIPTION.name, null))]
+        throw [newNullOrEmptyError('prescription cant be null or empty', generateFieldCause(prescriptionEntity, null))]
     }
     const statusError = this.getStatusError(prescription)
     const errors = this.getErrors(prescription).concat(this.getSpecificErrors(prescription))
@@ -19,31 +22,33 @@ const ISSUED = {
     status: 'EMITIDA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkDiferentValueError(prescription.status, null, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getDiferentValueError(prescription.status, null, prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
-        const errors = []
-        checkNotNull(prescription.issuedDate, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.issuedDate, errors)
-        checkNotNull(prescription.ttl, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.ttl, errors)
-        checkNotNull(prescription.affiliate, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.affiliate, errors)
-        checkNotNull(prescription.doctor, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.doctor, errors)
-        checkNotNull(prescription.medicalInsurance, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.medicalInsurance, errors)
-        checkNotNull(prescription.norm, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.norm, errors)
-        checkArrayNotEmpty(prescription.items, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.items, errors)
-        return errors
+        const errors = [
+            getNotNullError(prescription.issuedDate, prescriptionEntity, prescriptionFields.issuedDate),
+            getNotNullError(prescription.ttl, prescriptionEntity, prescriptionFields.ttl),
+            getNotNullError(prescription.affiliate, prescriptionEntity, prescriptionFields.affiliate),
+            getNotNullError(prescription.doctor, prescriptionEntity, prescriptionFields.doctor),
+            getNotNullError(prescription.medicalInsurance, prescriptionEntity, prescriptionFields.medicalInsurance),
+            getNotNullError(prescription.norm, prescriptionEntity, prescriptionFields.norm),
+            getArrayNotEmptyError(prescription.items, prescriptionEntity, prescriptionFields.items),
+        ]
+        return errors.filter(Boolean)
     },
     getSpecificErrors: (prescription) => {
-        const errors = []
-        checkDiferentValueError(prescription.soldDate, null, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.soldDate, errors)
-        checkDiferentValueError(prescription.auditedDate, null, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.auditedDate, errors)
-        return errors
+        const errors = [
+            getDiferentValueError(prescription.soldDate, null, prescriptionEntity, prescriptionFields.soldDate),
+            getDiferentValueError(prescription.auditedDate, null, prescriptionEntity, prescriptionFields.auditedDate)
+        ]
+        return errors.filter(Boolean)
     }
 }
 const CANCELLED = {
     status: 'CANCELADA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkDiferentValueError(prescription.status, ISSUED.status, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getDiferentValueError(prescription.status, ISSUED.status, prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         const errors = ISSUED.getErrors(prescription)
@@ -58,7 +63,7 @@ const CONFIRMED = {
     status: 'CONFIRMADA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkDiferentValueError(prescription.status, ISSUED.status, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getDiferentValueError(prescription.status, ISSUED.status, prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         const errors = ISSUED.getErrors(prescription)
@@ -73,7 +78,7 @@ const EXPIRED = {
     status: 'VENCIDA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkDiferentValueError(prescription.status, CONFIRMED.status, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getDiferentValueError(prescription.status, CONFIRMED.status, prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         const errors = CONFIRMED.getErrors(prescription)
@@ -89,7 +94,7 @@ const RECEIVED = {
     status: 'RECEPCIONADA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkValueNotInListError(prescription.status, [CONFIRMED.status, PARTIALLY_RECEIVED.status], codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getValueNotInListError(prescription.status, [CONFIRMED.status, PARTIALLY_RECEIVED.status], prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         let errors = []
@@ -111,7 +116,7 @@ const PARTIALLY_RECEIVED = {
     status: 'PARCIALMENTE_RECEPCIONADA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkDiferentValueError(prescription.status, CONFIRMED.status, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getDiferentValueError(prescription.status, CONFIRMED.status, prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         const errors = CONFIRMED.getErrors(prescription)
@@ -127,7 +132,7 @@ const INCOMPLETE = {
     status: 'INCOMPLETA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkDiferentValueError(prescription.status, PARTIALLY_RECEIVED.status, codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getDiferentValueError(prescription.status, PARTIALLY_RECEIVED.status, prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         const errors = PARTIALLY_RECEIVED.getErrors(prescription)
@@ -143,7 +148,7 @@ const AUDITED = {
     status: 'AUDITADA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         let errors = []
@@ -165,7 +170,7 @@ const REJECTED = {
     status: 'RECHAZADA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         let errors = []
@@ -187,7 +192,7 @@ const PARTIALLY_REJECTED = {
     status: 'PARCIALMENTE_RECHAZADA',
     validate: validator,
     getStatusError: (prescription) => {
-        return checkValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], codes.PRESCRIPTION.name, codes.PRESCRIPTION.fields.status)
+        return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status)
     },
     getErrors: (prescription) => {
         let errors = []

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -22,7 +22,7 @@ const errors = {
     FORBIDDEN_RESOURCE_EXCEPTION: {...error, code: "2-002", message: "You can´t perform that action", status: 403}
 }
 
-const newError = (type, message, status, cause) => {
+const newError = (type, message, cause, status) => {
     let anError = {...errors[type]}
     anError.message = message || anError.message
     anError.status = status || anError.status
@@ -30,16 +30,16 @@ const newError = (type, message, status, cause) => {
     return anError
 }
 
-const newUnexpectedError = (message, cause, status) => {return newError('UNEXPECTED_ERROR', message, status, cause)}
-const newGenericError = (message, cause, status) => {return newError('GENERIC_ERROR', message, status, cause)}
-const newDuplicatedValueError = (message, cause, status) => {return newError('DUPLICATED_VALUE_ERROR', message, status, cause)}
-const newNullOrEmptyError = (message, cause, status) => {return newError('NULL_OR_EMPTY_VALUE_ERROR', message, status, cause)}
-const newInvalidValueError = (message, cause, status) => {return newError('INVALID_VALUE_ERROR', message, status, cause)}
-const newEntityAlreadyCreated = (message, cause, status) => {return newError('ENTITY_ALREADY_CREATED', message, status, cause)}
-const newNotFoundError = (message, cause, status) => {return newError('NOT_FOUND_ERROR', message, status, cause)}
-const newInvalidUsernameOrPasswordError = (message, cause, status) => {return newError('INVALID_USERNAME_OR_PASSWORD_ERROR', message, status, cause)}
-const newSessionExpiredError = (message, cause, status) => {return newError('SESSION_EXPIRED_ERROR', message, status, cause)}
-const newForbiddenResourceException = (message, cause, status) => {return newError('FORBIDDEN_RESOURCE_EXCEPTION', message, status, cause)}
+const newUnexpectedError = (message, cause, status) => {return newError('UNEXPECTED_ERROR', message, cause, status)}
+const newGenericError = (message, cause, status) => {return newError('GENERIC_ERROR', message, cause, status)}
+const newDuplicatedValueError = (message, cause, status) => {return newError('DUPLICATED_VALUE_ERROR', message, cause, status)}
+const newNullOrEmptyError = (message, cause, status) => {return newError('NULL_OR_EMPTY_VALUE_ERROR', message, cause, status)}
+const newInvalidValueError = (message, cause, status) => {return newError('INVALID_VALUE_ERROR', message, cause, status)}
+const newEntityAlreadyCreated = (message, cause, status) => {return newError('ENTITY_ALREADY_CREATED', message, cause, status)}
+const newNotFoundError = (message, cause, status) => {return newError('NOT_FOUND_ERROR', message, cause, status)}
+const newInvalidUsernameOrPasswordError = (message, cause, status) => {return newError('INVALID_USERNAME_OR_PASSWORD_ERROR', message, cause, status)}
+const newSessionExpiredError = (message, cause, status) => {return newError('SESSION_EXPIRED_ERROR', message, cause, status)}
+const newForbiddenResourceException = (message, cause, status) => {return newError('FORBIDDEN_RESOURCE_EXCEPTION', message, cause, status)}
 
 const generateFieldCause = (entity, field, actualValue, expectedValue) => {
     const cause = {
@@ -57,62 +57,42 @@ const generateFieldCause = (entity, field, actualValue, expectedValue) => {
 }
 
 
-const checkNotNull = (value, entity, field, errors, message) => {
+const getNotNullError = (value, entity, field, message) => {
     if (!value){
-        const error = newNullOrEmptyError(message || `${entity} must have a value at ${field}`, generateFieldCause(entity, field, value))
-        if (!errors){
-            return error
-        } else {
-            errors.push(error)
-        }
+        return newNullOrEmptyError(message || `${entity} must have a value at ${field}`, generateFieldCause(entity, field, value))
     }
+    return null
 }
-const checkObjectNotEmpty = (value, entity, field, errors, message) => {
+const getObjectNotEmptyError = (value, entity, field, message) => {
     if (value instanceof Object){
         if (!Object.keys(value).length){
-            const error = newNullOrEmptyError(message || `${entity} must have at list one attribute on ${field}`, generateFieldCause(entity, field, value))
-            if (!errors){
-                return error
-            } else {
-                errors.push(error)
-            }
+            return newNullOrEmptyError(message || `${entity} must have at list one attribute on ${field}`, generateFieldCause(entity, field, value))
         }
     }
+    return null
 }
-const checkArrayNotEmpty = (value, entity, field, errors, message) => {
+const getArrayNotEmptyError = (value, entity, field, message) => {
     if (value instanceof Array){
         if (!value.length){
-            const error = newNullOrEmptyError(message || `${entity} must have at list one value at ${field}`, generateFieldCause(entity, field, value))
-            if (!errors){
-                return error
-            } else {
-                errors.push(error)
-            }
+            return newNullOrEmptyError(message || `${entity} must have at list one value at ${field}`, generateFieldCause(entity, field, value))
         }
     }
+    return null
 }
-const checkDiferentValueError = (value, otherValue, entity, field, errors, message) => {
+const getDiferentValueError = (value, otherValue, entity, field, message) => {
     if (value !== otherValue){
-        const error = newInvalidValueError(message || `${entity} ${field} must be ${otherValue}`, generateFieldCause(entity, field, value, otherValue))
-        if (!errors){
-            return error
-        } else {
-            errors.push(error)
-        }
+        return newInvalidValueError(message || `${entity} ${field} must be ${otherValue}`, generateFieldCause(entity, field, value, otherValue))
     }
+    return null
 }
-const checkValueNotInListError = (value, otherValues, entity, field, errors, message) => {
+const getValueNotInListError = (value, otherValues, entity, field, message) => {
     const found = otherValues.find((aValue) => {
         return aValue === value
     })
     if (!found){
-        const error = newInvalidValueError(message || `${entity} ${field} must be one of this ${otherValues}`, generateFieldCause(entity, field, value, otherValues))
-        if (!errors){
-            return error
-        } else {
-            errors.push(error)
-        }
+        return newInvalidValueError(message || `${entity} ${field} must be one of this ${otherValues}`, generateFieldCause(entity, field, value, otherValues))
     }
+    return null
 }
 
 module.exports = {
@@ -129,9 +109,9 @@ module.exports = {
     newForbiddenResourceException,
     _causes: causes,
     generateFieldCause,
-    checkArrayNotEmpty,
-    checkDiferentValueError,
-    checkNotNull,
-    checkObjectNotEmpty,
-    checkValueNotInListError
+    getArrayNotEmptyError,
+    getDiferentValueError,
+    getNotNullError,
+    getObjectNotEmptyError,
+    getValueNotInListError
 }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -11,7 +11,7 @@ const errors = {
     DUPLICATED_VALUE_ERROR: {...error, code: "1-000", message: "Duplicated field values"},
     NULL_OR_EMPTY_VALUE_ERROR: {...error, code: "1-001", message: "Null or empty field value"},
     INVALID_VALUE_ERROR: {...error, code: "1-002", message: "Invalid field value"},
-    ENTITY_ALLREADY_CREATED: {...error, code: "1-003", message: "Entity allready created"},
+    ENTITY_ALREADY_CREATED: {...error, code: "1-003", message: "Entity already created"},
     NOT_FOUND_ERROR: {...error, code: "1-100", message: "Not found"},
     INVALID_USERNAME_OR_PASSWORD_ERROR: {...error, code: "2-000", message: "Invalid username or password", status: 401},
     SESSION_EXPIRED_ERROR: {...error, code: "2-001", message: "Your session has expired", status: 403},
@@ -31,7 +31,7 @@ const newGenericError = (message, status, cause) => {return newError('GENERIC_ER
 const newDuplicatedValueError = (message, status, cause) => {return newError('DUPLICATED_VALUE_ERROR', message, status, cause)}
 const newNullOrEmptyError = (message, status, cause) => {return newError('NULL_OR_EMPTY_VALUE_ERROR', message, status, cause)}
 const newInvalidValueError = (message, status, cause) => {return newError('INVALID_VALUE_ERROR', message, status, cause)}
-const newEntityAllreadyCreated = (message, status, cause) => {return newError('ENTITY_ALLREADY_CREATED', message, status, cause)}
+const newEntityAlreadyCreated = (message, status, cause) => {return newError('ENTITY_ALREADY_CREATED', message, status, cause)}
 const newNotFoundError = (message, status, cause) => {return newError('NOT_FOUND_ERROR', message, status, cause)}
 const newInvalidUsernameOrPasswordError = (message, status, cause) => {return newError('INVALID_USERNAME_OR_PASSWORD_ERROR', message, status, cause)}
 const newSessionExpiredError = (message, status, cause) => {return newError('SESSION_EXPIRED_ERROR', message, status, cause)}
@@ -44,7 +44,7 @@ module.exports = {
     newDuplicatedValueError,
     newNullOrEmptyError,
     newInvalidValueError,
-    newEntityAllreadyCreated,
+    newEntityAlreadyCreated,
     newNotFoundError,
     newInvalidUsernameOrPasswordError,
     newSessionExpiredError,

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -11,6 +11,7 @@ const errors = {
     DUPLICATED_VALUE_ERROR: {...error, code: "1-000", message: "Duplicated field values"},
     NULL_OR_EMPTY_VALUE_ERROR: {...error, code: "1-001", message: "Null or empty field value"},
     INVALID_VALUE_ERROR: {...error, code: "1-002", message: "Invalid field value"},
+    ENTITY_ALLREADY_CREATED: {...error, code: "1-003", message: "Entity allready created"},
     NOT_FOUND_ERROR: {...error, code: "1-100", message: "Not found"},
     INVALID_USERNAME_OR_PASSWORD_ERROR: {...error, code: "2-000", message: "Invalid username or password", status: 401},
     SESSION_EXPIRED_ERROR: {...error, code: "2-001", message: "Your session has expired", status: 403},
@@ -30,6 +31,7 @@ const newGenericError = (message, status, cause) => {return newError('GENERIC_ER
 const newDuplicatedValueError = (message, status, cause) => {return newError('DUPLICATED_VALUE_ERROR', message, status, cause)}
 const newNullOrEmptyError = (message, status, cause) => {return newError('NULL_OR_EMPTY_VALUE_ERROR', message, status, cause)}
 const newInvalidValueError = (message, status, cause) => {return newError('INVALID_VALUE_ERROR', message, status, cause)}
+const newEntityAllreadyCreated = (message, status, cause) => {return newError('ENTITY_ALLREADY_CREATED', message, status, cause)}
 const newNotFoundError = (message, status, cause) => {return newError('NOT_FOUND_ERROR', message, status, cause)}
 const newInvalidUsernameOrPasswordError = (message, status, cause) => {return newError('INVALID_USERNAME_OR_PASSWORD_ERROR', message, status, cause)}
 const newSessionExpiredError = (message, status, cause) => {return newError('SESSION_EXPIRED_ERROR', message, status, cause)}
@@ -42,6 +44,7 @@ module.exports = {
     newDuplicatedValueError,
     newNullOrEmptyError,
     newInvalidValueError,
+    newEntityAllreadyCreated,
     newNotFoundError,
     newInvalidUsernameOrPasswordError,
     newSessionExpiredError,

--- a/test/unit/repositories/prescriptions-repository.spec.js
+++ b/test/unit/repositories/prescriptions-repository.spec.js
@@ -1,0 +1,122 @@
+const {PrescriptionRepository} = require('../../../src/repositories/prescriptions-repository')
+const {Prescription} = require('../../../src/domain/prescription')
+
+test('if you create a prescription ', () => {
+
+})
+
+describe('When creating a prescription', () => {
+    let prescription = new Prescription()
+    beforeEach(() => {
+        prescription = new Prescription()
+        return PrescriptionRepository.reset()
+    })
+
+    describe('and prescription hasn`t an id', () => {
+        beforeEach(() => {
+            prescription.id = null
+        })
+
+        it('PrescriptionRepositoy assigns an id to it', ()=> {
+            return PrescriptionRepository.create(prescription)
+            .then(pres => {
+                expect(pres.id).not.toBeNull()
+            })
+        })
+
+        it('PrescriptionRepositoy stores it and increment the repo`s count', ()=> {
+            return PrescriptionRepository.create(prescription)
+            .then(pres => {
+                return PrescriptionRepository.count()
+                .then(cantidad => {
+                    expect(cantidad).toBe(1)
+                })
+            })
+        })
+    })
+
+    describe('and prescription has an id', () => {
+        beforeEach(() => {
+            prescription.id = 1
+        })
+
+        it('PrescriptionRepositoy reject the promise with an error', ()=> {
+            return expect(PrescriptionRepository.create(prescription)).rejects.not.toBeNull()
+        })
+
+        it('PrescriptionRepositoy doesn`t increment the repo`s count', ()=> {
+            return PrescriptionRepository.create(prescription)
+            .catch(err => {
+                return PrescriptionRepository.count()
+                .then(cantidad => {
+                    expect(cantidad).toBe(0)
+                })
+            })
+        })
+    })
+})
+
+let prescription = new Prescription()
+beforeEach(() => {
+    prescription = new Prescription()
+    return PrescriptionRepository.reset()
+})
+
+test('when no prescriptions where created, PrescriptionRepository returns an empty array', () => {
+    return expect(PrescriptionRepository.getAll()).resolves.toEqual([])
+})
+
+test('when prescriptions where created, PrescriptionRepository returns all of the prescriptions', () => {
+    return PrescriptionRepository.create(new Prescription())
+    .then(prescription1 => {
+        PrescriptionRepository.create(new Prescription())
+        .then(prescription2 => {
+            PrescriptionRepository.getAll()
+            .then(prescriptions => {
+                expect(prescriptions).toContain(prescription1)
+                expect(prescriptions).toContain(prescription2)
+                expect(prescriptions.length).toBe(2)
+            })
+        })
+    })
+})
+
+//TODO: hacer los test para las actualizaciones
+
+describe('when you create some prescriptions', () => {
+    let prescription1 = new Prescription()
+    let prescription2 = new Prescription()
+    let prescription3 = new Prescription()
+    beforeEach(() => {
+        prescription1 = new Prescription()
+        prescription2 = new Prescription()
+        prescription3 = new Prescription()
+        PrescriptionRepository.reset()
+        .then(_ => {
+            return Promise.all([
+                PrescriptionRepository.create(prescription1).then(pres => {prescription1 = pres; return pres}),
+                PrescriptionRepository.create(prescription2).then(pres => {prescription2 = pres; return pres}),
+                PrescriptionRepository.create(prescription3).then(pres => {prescription3 = pres; return pres})
+            ])
+        })
+    })
+
+    describe('and want to get one by id', () => {
+        describe('and it`s a valid id', () => {
+            it('it returns the prescription', () => {
+                return PrescriptionRepository.getById(prescription1.id)
+                .then(pres => {
+                    expect(pres.id).toBe(prescription1.id)
+                })
+            })
+        })
+
+        describe('and it`s an invalid id', () => {
+            it('it rejects the search', () => {
+                return expect(PrescriptionRepository.getById(prescription1.id + 1)).rejects.not.toBeNull()
+            })
+        })
+    })
+
+    //TODO: hacer el resto de los test de busqueda por ejemplo y pos status
+})

--- a/test/unit/repositories/prescriptions-repository.spec.js
+++ b/test/unit/repositories/prescriptions-repository.spec.js
@@ -2,10 +2,6 @@ const {PrescriptionRepository} = require('../../../src/repositories/prescription
 const {Prescription} = require('../../../src/domain/prescription')
 const {states} = require('../../../src/state-machine/state')
 
-test('if you create a prescription ', () => {
-
-})
-
 describe('When creating a prescription', () => {
     let prescription = new Prescription()
     beforeEach(() => {

--- a/test/unit/state-machine/state.spec.js
+++ b/test/unit/state-machine/state.spec.js
@@ -1,0 +1,230 @@
+const {states} = require('../../../src/state-machine/state')
+const {Prescription} = require('../../../src/domain/prescription')
+const {_errors} = require('../../../src/utils/errors')
+const {codes} = require('../../../src/codes/entities-codes')
+
+test('State ISSUED has a status defined', () => {
+    expect(states.ISSUED.status).toBeDefined()
+    expect(states.ISSUED.status).toBeTruthy()
+})
+const getNewPrescription = () => {
+    let prescription = new Prescription()
+    return prescription
+}
+const getNewFullForIssued = () => {
+    let prescription = new Prescription()
+    prescription.id = null
+    prescription.setIssuedDate('01/01/2000 10:10')
+    prescription.setSoldDate('02/01/2000 10:10')
+    prescription.setAuditedDate('03/01/2000 10:10')
+    prescription.prolongedTreatment = false
+    prescription.diagnosis = 'diagnostico'
+    prescription.ttl = 30
+    prescription.institution = {id: 1}
+    prescription.affiliate = {id: 1}
+    prescription.doctor = {id: 1}
+    prescription.medicalInsurance = {id: 1}
+    prescription.status = states.ISSUED.status
+    prescription.norm = {id: 1}
+    prescription.addItem({id: 1})
+    return prescription
+}
+const getNewPrescriptionForIssued = () => {
+    let prescription = new Prescription()
+    prescription.setIssuedDate('01/01/2000 10:10')
+    prescription.prolongedTreatment = false
+    prescription.ttl = 30
+    prescription.institution = {id: 1}
+    prescription.affiliate = {id: 1}
+    prescription.doctor = {id: 1}
+    prescription.medicalInsurance = {id: 1}
+    prescription.norm = {id: 1}
+    prescription.addItem({id: 1})
+    return prescription
+}
+describe('when state ISSUED has to validate a prescription', () => {
+    describe('and prescription is null, undefined or not truthy', () => {
+        it('it throws an error', () => {
+            expect(() => {states.ISSUED.validate()}).toThrow()
+            expect(() => {states.ISSUED.validate(null)}).toThrow()
+            expect(() => {states.ISSUED.validate('')}).toThrow()
+        })
+    })
+
+    describe('and prescription has a status setted', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.status = 'XXX'
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.status)
+            }
+        })
+    })
+
+    describe('and prescription hasn`t an issuedDate', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.setIssuedDate(null)
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.issuedDate)
+            }
+        })
+    })
+
+    describe('and prescription hasn`t a ttl', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.ttl = null
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.ttl)
+            }
+        })
+    })
+
+    describe('and prescription hasn`t an affiliate', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.affiliate = null
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.affiliate)
+            }
+        })
+    })
+
+    describe('and prescription hasn`t a doctor', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.doctor = null
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.doctor)
+            }
+        })
+    })
+
+    describe('and prescription hasn`t a medicalInsurance', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.medicalInsurance = null
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.medicalInsurance)
+            }
+        })
+    })
+
+    describe('and prescription hasn`t a norm', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.norm = null
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.norm)
+            }
+        })
+    })
+
+    describe('and prescription has no items setted', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.items = []
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.items)
+            }
+        })
+    })
+
+    describe('and prescription has a soldDate', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.setSoldDate('02/01/01 10:10')
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.soldDate)
+            }
+        })
+    })
+
+    describe('and prescription has a auditedDate', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.setAuditedDate('03/01/01 10:10')
+        it('it throws an error that specifies an error on field', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (e) {
+                expect(e.length).toBe(1)
+                const error = e[0]
+                expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
+                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.auditedDate)
+            }
+        })
+    })
+
+    describe('and prescription is ok', () => {
+        const prescription = getNewPrescriptionForIssued()
+        it('it validates the prescription', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).not.toThrow()
+        })
+    })
+})

--- a/test/unit/state-machine/state.spec.js
+++ b/test/unit/state-machine/state.spec.js
@@ -58,9 +58,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.status)
@@ -75,9 +75,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.issuedDate)
@@ -92,9 +92,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.ttl)
@@ -109,9 +109,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.affiliate)
@@ -126,9 +126,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.doctor)
@@ -143,9 +143,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.medicalInsurance)
@@ -160,9 +160,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.norm)
@@ -177,9 +177,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.items)
@@ -194,9 +194,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.soldDate)
@@ -211,9 +211,9 @@ describe('when state ISSUED has to validate a prescription', () => {
             expect(() => {states.ISSUED.validate(prescription)}).toThrow()
             try {
                 states.ISSUED.validate(prescription)
-            } catch (e) {
-                expect(e.length).toBe(1)
-                const error = e[0]
+            } catch (errors) {
+                expect(errors.length).toBe(1)
+                const error = errors[0]
                 expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
                 expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
                 expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.auditedDate)
@@ -221,10 +221,25 @@ describe('when state ISSUED has to validate a prescription', () => {
         })
     })
 
+    describe('and prescription has various errors', () => {
+        const prescription = getNewPrescriptionForIssued()
+        prescription.status = states.ISSUED.status
+        prescription.setIssuedDate(null)
+        it('it throws an error that specifies all errors', () => {
+            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
+            try {
+                states.ISSUED.validate(prescription)
+            } catch (errors) {
+                expect(errors.length).toBe(2)
+            }
+        })
+    })
+
     describe('and prescription is ok', () => {
         const prescription = getNewPrescriptionForIssued()
-        it('it validates the prescription', () => {
+        it('it validates the prescription and leaves it untouched', () => {
             expect(() => {states.ISSUED.validate(prescription)}).not.toThrow()
+            expect(prescription).toEqual(getNewPrescriptionForIssued())
         })
     })
 })

--- a/test/unit/utils/errors.spec.js
+++ b/test/unit/utils/errors.spec.js
@@ -11,7 +11,7 @@ test('new unexpectedError error can be created with custom message, status and c
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newUnexpectedError(message, status, cause)
+    const error = errors.newUnexpectedError(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -28,7 +28,7 @@ test('new genericError error can be created with custom message, status and caus
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newGenericError(message, status, cause)
+    const error = errors.newGenericError(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -45,7 +45,7 @@ test('new duplicatedValueError error can be created with custom message, status 
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newDuplicatedValueError(message, status, cause)
+    const error = errors.newDuplicatedValueError(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -62,7 +62,7 @@ test('new nullOrEmptyError error can be created with custom message, status and 
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newNullOrEmptyError(message, status, cause)
+    const error = errors.newNullOrEmptyError(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -79,7 +79,7 @@ test('new invalidValueError error can be created with custom message, status and
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newInvalidValueError(message, status, cause)
+    const error = errors.newInvalidValueError(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -96,7 +96,7 @@ test('new entityAlreadyCreated error can be created with custom message, status 
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newEntityAlreadyCreated(message, status, cause)
+    const error = errors.newEntityAlreadyCreated(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -113,7 +113,7 @@ test('new notFoundError error can be created with custom message, status and cau
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newNotFoundError(message, status, cause)
+    const error = errors.newNotFoundError(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -130,7 +130,7 @@ test('new invalidUsernameOrPasswordError error can be created with custom messag
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newInvalidUsernameOrPasswordError(message, status, cause)
+    const error = errors.newInvalidUsernameOrPasswordError(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -147,7 +147,7 @@ test('new sessionExpiredError error can be created with custom message, status a
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newSessionExpiredError(message, status, cause)
+    const error = errors.newSessionExpiredError(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)
@@ -164,7 +164,7 @@ test('new forbiddenResourceError error can be created with custom message, statu
     const message = 'ERROR'
     const status = 1000
     const cause = {}
-    const error = errors.newForbiddenResourceException(message, status, cause)
+    const error = errors.newForbiddenResourceException(message, cause, status)
     expect(error.message).toBe(message)
     expect(error.status).toBe(status)
     expect(error.cause).toEqual(cause)

--- a/test/unit/utils/errors.spec.js
+++ b/test/unit/utils/errors.spec.js
@@ -85,6 +85,23 @@ test('new invalidValueError error can be created with custom message, status and
     expect(error.cause).toEqual(cause)
 })
 
+test('new entityAlreadyCreated error can be created with default message, status and cause', () => {
+    const error = errors.newEntityAlreadyCreated()
+    expect(error.message).toBe(errors._errors.ENTITY_ALREADY_CREATED.message)
+    expect(error.status).toBe(errors._errors.ENTITY_ALREADY_CREATED.status)
+    expect(error.cause).toEqual(errors._errors.ENTITY_ALREADY_CREATED.cause)
+})
+
+test('new entityAlreadyCreated error can be created with custom message, status and cause', () => {
+    const message = 'ERROR'
+    const status = 1000
+    const cause = {}
+    const error = errors.newEntityAlreadyCreated(message, status, cause)
+    expect(error.message).toBe(message)
+    expect(error.status).toBe(status)
+    expect(error.cause).toEqual(cause)
+})
+
 test('new notFoundError error can be created with default message, status and cause', () => {
     const error = errors.newNotFoundError()
     expect(error.message).toBe(errors._errors.NOT_FOUND_ERROR.message)


### PR DESCRIPTION
- Se agregan dos nuevos comandos para coverage y veroboso
- Se crea una abstracción de códigos de entidades y campos para manejo de errores y chequeo
- Se agrega un metodo de reset al PrescriptionRepository y se hace una implementecion muy vaga del update
- Se pasan las funciones de validación de campos del state.js al errors.js
- Se cambia la firma de estas funciones de validaciones para poder estandarizar el manejo de errores y como van a llegar al front
- Se agrega un nuevo error ENTITY_ALLREADY_CREATED
- Se agregan los tests para PrescriptionRepository
- Se agregan los tests para state.js
- Se arreglan los tests de errores para que usen la nueva firma