### PR TITLE
Ver historial recetas y algo mas

### DIFF
--- a/src/filters/prescriptionFilters.js
+++ b/src/filters/prescriptionFilters.js
@@ -1,0 +1,152 @@
+const lang = require('lodash/lang')
+const {formats} = require('../utils/utils')
+const {states} = require('../state-machine/state')
+
+const availableStates = Object.keys(states).reduce((map, state) => {
+    map[state] = {
+        id: state, 
+        value: states[state].status
+    } 
+    return map
+}, {})
+
+const prescriptionFilters = {
+    singles: {
+        id: {
+            key: "id",
+        },
+        status: {
+            key: "status",
+            values: []
+        },
+        institution: {
+            key: "institution",
+            values: []
+        },
+        medicalInsurance: {
+            key: "medicalInsurance",
+            values: []
+        },
+        affiliate: {
+            key: "affiliate"
+        },
+        doctor: {
+            key: "doctor"
+        },
+        pharmacist: {
+            key: "pharmacist"
+        },
+        medicine: {
+            key: "medicine"
+        }
+    },
+    ranges: {
+        issueDateRange: {
+            keyFrom: "fromIssueDate",
+            keyTo: "toIssueDate",
+            format: formats.dateTimeFormat
+        },
+        receivedDateRange: {
+            keyFrom: "fromReceivedDate",
+            keyTo: "toReceivedDate",
+            format: formats.dateTimeFormat
+        },
+        auditedDateRange: {
+            keyFrom: "fromAuditedDate",
+            keyTo: "toAuditedDate",
+            format: formats.dateTimeFormat
+        }
+    },
+    orders: {
+        key: "orderBy",
+        values: {
+            id: {
+                key: "id",
+                sorting: {
+                    asc: "asc"
+                }
+            },
+            issuedDate: {
+                key: "issuedDate",
+                sorting: {
+                    asc: "asc",
+                    dsc: "desc"
+                }
+            },
+            soldDate: {
+                key: "soldDate",
+                sorting: {
+                    asc: "asc",
+                    dsc: "desc"
+                }
+            },
+            auditedDate: {
+                key: "audtitedDate",
+                sorting: {
+                    asc: "asc",
+                    dsc: "desc"
+                }
+            }
+        }
+    }
+}
+
+const doctorAvailableFilters = {filters: {singles: {}, ranges: {}}, specialFilters: {singles: {}, ranges: {}}, orders: {key: prescriptionFilters.orders.key, values: {}}}
+doctorAvailableFilters.filters.singles.id = lang.cloneDeep(prescriptionFilters.singles.id)
+doctorAvailableFilters.filters.singles.status = lang.cloneDeep(prescriptionFilters.singles.status)
+doctorAvailableFilters.filters.singles.status.values = [availableStates.ISSUED, availableStates.CANCELLED, availableStates.CONFIRMED, availableStates.INCOMPLETE, availableStates.AUDITED, availableStates.REJECTED, availableStates.PARTIALLY_REJECTED]
+doctorAvailableFilters.filters.ranges.issueDateRange = lang.cloneDeep(prescriptionFilters.ranges.issueDateRange)
+doctorAvailableFilters.specialFilters.singles.institution = lang.cloneDeep(prescriptionFilters.singles.institution)
+doctorAvailableFilters.specialFilters.singles.medicalInsurance = lang.cloneDeep(prescriptionFilters.singles.medicalInsurance)
+doctorAvailableFilters.specialFilters.singles.medicine = lang.cloneDeep(prescriptionFilters.singles.medicine)
+doctorAvailableFilters.orders.values.id = lang.cloneDeep(prescriptionFilters.orders.values.id)
+doctorAvailableFilters.orders.values.issuedDate = lang.cloneDeep(prescriptionFilters.orders.values.issuedDate)
+
+const affiliateAvailableFilters = {filters: {singles: {}, ranges: {}}, specialFilters: {singles: {}, ranges: {}}, orders: {key: prescriptionFilters.orders.key, values: {}}}
+affiliateAvailableFilters.filters.singles.id = lang.cloneDeep(prescriptionFilters.singles.id)
+affiliateAvailableFilters.filters.singles.status = lang.cloneDeep(prescriptionFilters.singles.status)
+affiliateAvailableFilters.filters.singles.status.values = [availableStates.CONFIRMED, availableStates.EXPIRED, availableStates.RECEIVED, availableStates.PARTIALLY_RECEIVED]
+affiliateAvailableFilters.filters.ranges.issueDateRange = lang.cloneDeep(prescriptionFilters.ranges.issueDateRange)
+affiliateAvailableFilters.filters.ranges.receivedDateRange = lang.cloneDeep(prescriptionFilters.ranges.receivedDateRange)
+affiliateAvailableFilters.specialFilters.singles.institution = lang.cloneDeep(prescriptionFilters.singles.institution)
+affiliateAvailableFilters.specialFilters.singles.medicalInsurance = lang.cloneDeep(prescriptionFilters.singles.medicalInsurance)
+affiliateAvailableFilters.orders.values.id = lang.cloneDeep(prescriptionFilters.orders.values.id)
+affiliateAvailableFilters.orders.values.issuedDate = lang.cloneDeep(prescriptionFilters.orders.values.issuedDate)
+affiliateAvailableFilters.orders.values.soldDate = lang.cloneDeep(prescriptionFilters.orders.values.soldDate)
+
+const pharmacistAvailableFilters = {filters: {singles: {}, ranges: {}}, specialFilters: {singles: {}, ranges: {}}, orders: {key: prescriptionFilters.orders.key, values: {}}}
+pharmacistAvailableFilters.filters.singles.id = lang.cloneDeep(prescriptionFilters.singles.id)
+pharmacistAvailableFilters.filters.singles.status = lang.cloneDeep(prescriptionFilters.singles.status)
+pharmacistAvailableFilters.filters.singles.status.values = [availableStates.RECEIVED, availableStates.PARTIALLY_RECEIVED, availableStates.INCOMPLETE, availableStates.AUDITED, availableStates.REJECTED, availableStates.PARTIALLY_REJECTED]
+pharmacistAvailableFilters.filters.ranges.issueDateRange = lang.cloneDeep(prescriptionFilters.ranges.issueDateRange)
+pharmacistAvailableFilters.filters.ranges.receivedDateRange = lang.cloneDeep(prescriptionFilters.ranges.receivedDateRange)
+pharmacistAvailableFilters.specialFilters.singles.institution = lang.cloneDeep(prescriptionFilters.singles.institution)
+pharmacistAvailableFilters.specialFilters.singles.medicalInsurance = lang.cloneDeep(prescriptionFilters.singles.medicalInsurance)
+pharmacistAvailableFilters.specialFilters.singles.medicine = lang.cloneDeep(prescriptionFilters.singles.medicine)
+pharmacistAvailableFilters.orders.values.id = lang.cloneDeep(prescriptionFilters.orders.values.id)
+pharmacistAvailableFilters.orders.values.issuedDate = lang.cloneDeep(prescriptionFilters.orders.values.issuedDate)
+pharmacistAvailableFilters.orders.values.soldDate = lang.cloneDeep(prescriptionFilters.orders.values.soldDate)
+
+const medicalInsuranceAvailableFilters = {filters: {singles: {}, ranges: {}}, specialFilters: {singles: {}, ranges: {}}, orders: {key: prescriptionFilters.orders.key, values: {}}}
+medicalInsuranceAvailableFilters.filters.singles.id = lang.cloneDeep(prescriptionFilters.singles.id)
+medicalInsuranceAvailableFilters.filters.singles.status = lang.cloneDeep(prescriptionFilters.singles.status)
+medicalInsuranceAvailableFilters.filters.singles.status.values = [availableStates.ISSUED, availableStates.CANCELLED, availableStates.CONFIRMED, availableStates.EXPIRED, availableStates.RECEIVED, availableStates.PARTIALLY_RECEIVED, availableStates.INCOMPLETE, availableStates.AUDITED, availableStates.REJECTED, availableStates.PARTIALLY_REJECTED]
+medicalInsuranceAvailableFilters.filters.ranges.issueDateRange = lang.cloneDeep(prescriptionFilters.ranges.issueDateRange)
+medicalInsuranceAvailableFilters.filters.ranges.receivedDateRange = lang.cloneDeep(prescriptionFilters.ranges.receivedDateRange)
+medicalInsuranceAvailableFilters.filters.ranges.auditedDateRange = lang.cloneDeep(prescriptionFilters.ranges.auditedDateRange)
+medicalInsuranceAvailableFilters.specialFilters.singles.institution = lang.cloneDeep(prescriptionFilters.singles.institution)
+medicalInsuranceAvailableFilters.specialFilters.singles.doctor = lang.cloneDeep(prescriptionFilters.singles.doctor)
+medicalInsuranceAvailableFilters.specialFilters.singles.affiliate = lang.cloneDeep(prescriptionFilters.singles.affiliate)
+medicalInsuranceAvailableFilters.specialFilters.singles.pharmacist = lang.cloneDeep(prescriptionFilters.singles.pharmacist)
+medicalInsuranceAvailableFilters.specialFilters.singles.medicine = lang.cloneDeep(prescriptionFilters.singles.medicine)
+medicalInsuranceAvailableFilters.orders.values.id = lang.cloneDeep(prescriptionFilters.orders.values.id)
+medicalInsuranceAvailableFilters.orders.values.issuedDate = lang.cloneDeep(prescriptionFilters.orders.values.issuedDate)
+medicalInsuranceAvailableFilters.orders.values.soldDate = lang.cloneDeep(prescriptionFilters.orders.values.soldDate)
+medicalInsuranceAvailableFilters.orders.values.auditedDate = lang.cloneDeep(prescriptionFilters.orders.values.auditedDate)
+
+module.exports = {
+    getAffiliateAvailableFilters: () => {return lang.cloneDeep(pharmacistAvailableFilters)},
+    getDoctorAvailableFilters: () => {return lang.cloneDeep(doctorAvailableFilters)},
+    getPharmacistAvailableFilters: () => {return lang.cloneDeep(pharmacistAvailableFilters)},
+    getMedicalInsuranceAvailableFilters: () => {return lang.cloneDeep(medicalInsuranceAvailableFilters)}
+}

--- a/src/filters/prescriptionFilters.js
+++ b/src/filters/prescriptionFilters.js
@@ -1,6 +1,9 @@
 const lang = require('lodash/lang')
+const array = require('lodash/array')
 const {formats} = require('../utils/utils')
 const {states} = require('../state-machine/state')
+const errors = require('../utils/errors')
+const {codes} = require('../codes/entities-codes')
 
 const availableStates = Object.keys(states).reduce((map, state) => {
     map[state] = {
@@ -144,9 +147,64 @@ medicalInsuranceAvailableFilters.orders.values.issuedDate = lang.cloneDeep(presc
 medicalInsuranceAvailableFilters.orders.values.soldDate = lang.cloneDeep(prescriptionFilters.orders.values.soldDate)
 medicalInsuranceAvailableFilters.orders.values.auditedDate = lang.cloneDeep(prescriptionFilters.orders.values.auditedDate)
 
+const getAffiliateAvailableFilters = () => {return lang.cloneDeep(pharmacistAvailableFilters)}
+const getDoctorAvailableFilters = () => {return lang.cloneDeep(doctorAvailableFilters)}
+const getPharmacistAvailableFilters = () => {return lang.cloneDeep(pharmacistAvailableFilters)}
+const getMedicalInsuranceAvailableFilters = () => {return lang.cloneDeep(medicalInsuranceAvailableFilters)}
+
+const getAvailableFilterKeys = (availableFilters) => {
+    return array.concat(
+        Object.keys(availableFilters.filters.singles).map((single) => availableFilters.filters.singles[single].key),
+        Object.keys(availableFilters.filters.ranges).map((single) => availableFilters.filters.ranges[single].keyFrom),
+        Object.keys(availableFilters.filters.ranges).map((single) => availableFilters.filters.ranges[single].keyTo),
+        Object.keys(availableFilters.specialFilters.singles).map((single) => availableFilters.specialFilters.singles[single].key),
+        Object.keys(availableFilters.specialFilters.ranges).map((single) => availableFilters.specialFilters.ranges[single].keyFrom),
+        Object.keys(availableFilters.specialFilters.ranges).map((single) => availableFilters.specialFilters.ranges[single].keyTo)
+    )
+}
+const getAvailableOrderKeys = (availableFilters) => {
+    return array.concat(
+        Object.keys(availableFilters.orders.values).map((value) => availableFilters.orders.values[value].key)
+    )
+}
+
+const affiliateAvailableFilterKeys = getAvailableFilterKeys(getAffiliateAvailableFilters())
+const doctorAvailableFilterKeys = getAvailableFilterKeys(getDoctorAvailableFilters())
+const pharmacistAvailableFilterKeys = getAvailableFilterKeys(getPharmacistAvailableFilters())
+const medicalInsuranceAvailableFilterKey = getAvailableFilterKeys(getMedicalInsuranceAvailableFilters())
+const affiliateAvailableOrderKeys = getAvailableOrderKeys(getAffiliateAvailableFilters())
+const doctorAvailableOrderKeys = getAvailableOrderKeys(getDoctorAvailableFilters())
+const pharmacistAvailableOrderKeys = getAvailableOrderKeys(getPharmacistAvailableFilters())
+const medicalInsuranceAvailableOrderKeys = getAvailableOrderKeys(getMedicalInsuranceAvailableFilters())
+
+
+const queryBuilder = (params, availableFilters, availableFilterKeys, availableOrderKeys) => {
+    // const queryObject = {isValid: true}
+    // if (!params || typeof params !== 'object' || params instanceof Array){
+    //     queryObject.isValid = false
+    //     return queryObject
+    // }
+    // const validKeys = array.intersection(Object.keys(params), array.concat(availableFilterKeys, [availableFilters.orders.key]))
+    // validKeys.every((key) => validateValue(key, params[key], availableFilters))
+}
+
+const validateValue = (key, value, availableFilters) => {
+     if (availableFilters.filters.single[key]){
+         if (availableFilters.filters.single[key].values){
+            availableFilters.filters.single[key].values.map((value) => value.value)
+         } else {
+
+         }
+     }
+}
+
 module.exports = {
-    getAffiliateAvailableFilters: () => {return lang.cloneDeep(pharmacistAvailableFilters)},
-    getDoctorAvailableFilters: () => {return lang.cloneDeep(doctorAvailableFilters)},
-    getPharmacistAvailableFilters: () => {return lang.cloneDeep(pharmacistAvailableFilters)},
-    getMedicalInsuranceAvailableFilters: () => {return lang.cloneDeep(medicalInsuranceAvailableFilters)}
+    getAffiliateAvailableFilters,
+    getDoctorAvailableFilters,
+    getPharmacistAvailableFilters,
+    getMedicalInsuranceAvailableFilters,
+    getAffiliateQueryByParams: (params) => {return queryBuilder(params, getAffiliateAvailableFilters(), affiliateAvailableFilterKeys, affiliateAvailableOrderKeys)},
+    getDoctorQueryByParams: (params) => {return queryBuilder(params, getDoctorAvailableFilters(), doctorAvailableFilterKeys, doctorAvailableOrderKeys)},
+    getPharmacistQueryByParams: (params) => {return queryBuilder(params, getPharmacistAvailableFilters(), pharmacistAvailableFilterKeys, pharmacistAvailableOrderKeys)},
+    getMedicalInsuranceQueryByParams: (params) => {return queryBuilder(params, getMedicalInsuranceAvailableFilters(), medicalInsuranceAvailableFilterKey, medicalInsuranceAvailableOrderKeys)}
 }

--- a/src/repositories/prescriptions-repository.js
+++ b/src/repositories/prescriptions-repository.js
@@ -88,6 +88,12 @@ class PrescriptionRepository {
             return resolve(prescriptions)
         })
     }
+
+    getByQuery(query){
+        return new Promise((resolve, reject) => {
+            return resolve([...this.prescriptions])
+        })
+    }
 }
 
 module.exports = {PrescriptionRepository: new PrescriptionRepository()}

--- a/src/routes/prescriptions.js
+++ b/src/routes/prescriptions.js
@@ -23,7 +23,7 @@ router.post('/', (req, res, next) => {
 
 const secureMiddleware = (req, res, next) => {
     req.identifiedUser = {
-        type: 'doctor',
+        type: 'affiliate',
         id: 1
     }
     return next()
@@ -36,9 +36,17 @@ const filtersBy = {
     medicalInsurance: {getFilters: filters.getMedicalInsuranceAvailableFilters}
 }
 
+const queryBy = {
+    affiliate: {getQuery: filters.getAffiliateQueryByParams},
+    doctor: {getQuery: filters.getDoctorQueryByParams},
+    pharmacist: {getQuery: filters.getPharmacistQueryByParams},
+    medicalInsurance: {getQuery: filters.getMedicalInsuranceQueryByParams},
+}
+
 router.get('/', secureMiddleware, (req, res, next) => {
     const {logger} = req.app.locals
-    return PrescriptionRepository.getByExample({affiliate: {id: req.identifiedUser.id}})
+    const prescriptionQuery = queryBy[req.identifiedUser.type] && queryBy[req.identifiedUser.type].getQuery(req.query) || {}
+    return PrescriptionRepository.getAll()
     .then(prescirptions => {
         const filters = filtersBy[req.identifiedUser.type] && filtersBy[req.identifiedUser.type].getFilters() || {}
         const response = {result: prescirptions.map(pres => pres.toPlainObject()), ...filters}

--- a/src/routes/prescriptions.js
+++ b/src/routes/prescriptions.js
@@ -46,7 +46,7 @@ const queryBy = {
 router.get('/', secureMiddleware, (req, res, next) => {
     const {logger} = req.app.locals
     const prescriptionQuery = queryBy[req.identifiedUser.type] && queryBy[req.identifiedUser.type].getQuery(req.query) || {}
-    return PrescriptionRepository.getAll()
+    return PrescriptionRepository.getByQuery(prescriptionQuery)
     .then(prescirptions => {
         const filters = filtersBy[req.identifiedUser.type] && filtersBy[req.identifiedUser.type].getFilters() || {}
         const response = {result: prescirptions.map(pres => pres.toPlainObject()), ...filters}

--- a/src/routes/prescriptions.js
+++ b/src/routes/prescriptions.js
@@ -3,6 +3,8 @@ const router = express.Router()
 const {Prescription} = require('../domain/prescription')
 const {StateMachine} = require('../state-machine/state-machine')
 const {newBadRequestError, isBusinessError} = require('../utils/errors')
+const {PrescriptionRepository} = require('../repositories/prescriptions-repository')
+const filters = require('../filters/prescriptionFilters')
 
 router.post('/', (req, res, next) => {
     const {logger} = req.app.locals
@@ -15,6 +17,34 @@ router.post('/', (req, res, next) => {
         if (isBusinessError(err)){
             return next(newBadRequestError('Invalid prescription payload', err, 400))
         }
+        return next(err)
+    })
+})
+
+const secureMiddleware = (req, res, next) => {
+    req.identifiedUser = {
+        type: 'doctor',
+        id: 1
+    }
+    return next()
+}
+
+const filtersBy = {
+    affiliate: {getFilters: filters.getAffiliateAvailableFilters},
+    doctor: {getFilters: filters.getDoctorAvailableFilters},
+    pharmacist: {getFilters: filters.getPharmacistAvailableFilters},
+    medicalInsurance: {getFilters: filters.getMedicalInsuranceAvailableFilters}
+}
+
+router.get('/', secureMiddleware, (req, res, next) => {
+    const {logger} = req.app.locals
+    return PrescriptionRepository.getByExample({affiliate: {id: req.identifiedUser.id}})
+    .then(prescirptions => {
+        const filters = filtersBy[req.identifiedUser.type] && filtersBy[req.identifiedUser.type].getFilters() || {}
+        const response = {result: prescirptions.map(pres => pres.toPlainObject()), ...filters}
+        return res.json(response)
+    })
+    .catch(err => {
         return next(err)
     })
 })

--- a/src/state-machine/state.js
+++ b/src/state-machine/state.js
@@ -33,15 +33,15 @@ const ISSUED = {
             getNotNullError(prescription.issuedDate, prescriptionEntity, prescriptionFields.issuedDate),
             getNotNullError(prescription.ttl, prescriptionEntity, prescriptionFields.ttl),
             getNotNullError(prescription.affiliate, prescriptionEntity, prescriptionFields.affiliate),
-            getObjectDoesntMatchError(prescription, 'affiliate.id', undefined, affiliateEntity, affiliateFields.id),
+            getObjectDoesntMatchError(prescription, 'affiliate.id', (value) => {return typeof value === 'number' && !!value}, affiliateEntity, affiliateFields.id),
             getNotNullError(prescription.doctor, prescriptionEntity, prescriptionFields.doctor),
-            getObjectDoesntMatchError(prescription, 'doctor.id', undefined, doctorEntity, doctorFields.id),
+            getObjectDoesntMatchError(prescription, 'doctor.id', (value) => {return typeof value === 'number' && !!value}, doctorEntity, doctorFields.id),
             getNotNullError(prescription.medicalInsurance, prescriptionEntity, prescriptionFields.medicalInsurance),
-            getObjectDoesntMatchError(prescription, 'medicalInsurance.id', undefined, medicalInsuranceEntity, medicalInsuranceFields.id),
+            getObjectDoesntMatchError(prescription, 'medicalInsurance.id', (value) => {return typeof value === 'number' && !!value}, medicalInsuranceEntity, medicalInsuranceFields.id),
             getNotNullError(prescription.norm, prescriptionEntity, prescriptionFields.norm),
             getArrayNotEmptyError(prescription.items, prescriptionEntity, prescriptionFields.items),
-            ...getArrayDoesntMatchError(prescription.items, 'prescribed.quantity', undefined, itemEntity, itemFields.prescribed.quantity),
-            ...getArrayDoesntMatchError(prescription.items, 'prescribed.medicine.id', undefined, itemEntity, itemFields.prescribed.medicine.id)
+            ...getArrayDoesntMatchError(prescription.items, 'prescribed.quantity', (value) => {return typeof value === 'number' && !!value}, itemEntity, itemFields.prescribed.quantity),
+            ...getArrayDoesntMatchError(prescription.items, 'prescribed.medicine.id', (value) => {return typeof value === 'number' && !!value}, itemEntity, itemFields.prescribed.medicine.id)
         ]
         return errors
     },

--- a/test/e2e/routes/institutions.spec.js
+++ b/test/e2e/routes/institutions.spec.js
@@ -3,6 +3,7 @@ const { init } = require('../../../src/init/initServer')
 const { InstitutionRepository } = require('../../../src/repositories/institutionRepository')
 
 const app = init()
+app.locals.logger = {info: () => {}, error: () => {}}
 
 describe('when do a get in /institutions', () => {
   describe('and the repository response ok', () => {

--- a/test/unit/middlewares/error-handler.spec.js
+++ b/test/unit/middlewares/error-handler.spec.js
@@ -8,7 +8,7 @@ describe('when err passed to middleware errorHandler', () => {
     let next = null
 
     beforeEach(() => {
-        err = errors.newGenericError()
+        err = errors.newBadRequestError()
         req = {app: {locals:{logger:{info: () => {}}}}}
         res = {
             json: jest.fn((json) => {}),


### PR DESCRIPTION
Ahí va un commit no muy grande pero complejo de seguir.
La finalidad de lo que está hecho es poder enviar al front los filtros y ordenes disponibles para el tipo de usuario que consulta y al recibir un query por alguno de esos filtros, poder filtrar los que realmente tiene habilitado el usuario. Por ejemplo si un paciente intentara filtrar por estado CANCELLED y no se encuentra dentro de su lista de filtros disponibles o no tiene habilitado para filtrar por CANCELLED, se ignora ese filtro.
- Se crea un objeto que tiene todos los filtros genericos para todos los usuarios
- Se usa ese objeto para crear los filtros específicos para cada tipo de usuario
- Se crean funciones para poder obtener una nueva instancia de estos filtros
- Se creó una funcion que transforma un objeto de filtro disponible de algun tipo de usuario a un objeto mas facilmente accesible para filtrar los valores de la query
- Se crea una funcion que apartir de los filtros disponibles para un usuario y la lista de parametros que haya enviado, devuelve el query que representa validado y formateado.
- Se crea un metodo en el Repo de Prescriptions que recibe un query y devuelve la lista de recetas que machea con el query
- Se crea el endpoint para consulta de recetas con un minimiddleware creado ahi mismo que simula un usuario logueado
- Se refactorizan dos funciones para validar payloads para que sean mas genericas y útiles