### PR TITLE
Fix: linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,13 +10,17 @@
     "SharedArrayBuffer": "readonly",
     "describe": true,
     "expect": true,
-    "it": true
+    "it": true,
+    "test": true,
+    "beforeEach": true,
+    "beforeAll": true,
+    "jest": true
   },
   "parserOptions": {
     "ecmaVersion": 2018
   },
   "rules": {
-    "max-len": ["warn", 120],
+    "max-len": ["warn", 160],
     "semi": ["error", "never"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "node src",
     "test": "NODE_ENV=test jest",
+    "lint": "eslint ./src/** ./test/**",
+    "lint:fix": "eslint ./src/** ./test/** --fix",
     "test:watch": "NODE_ENV=test jest --watch --verbose",
     "test:coverage": "NODE_ENV=test jest --coverage",
     "test:verbose": "NODE_ENV=test jest --verbose"

--- a/src/bootstrap/bootstrap.js
+++ b/src/bootstrap/bootstrap.js
@@ -1,42 +1,42 @@
-const {Affiliate} = require('../domain/affiliate')
-const {Doctor} = require('../domain/doctor')
-const {Institution} = require('../domain/institution')
-const {Item} = require('../domain/item')
-const {MedicalInsurance} = require('../domain/medicalInsurance')
-const {Medicine} = require('../domain/medicine')
-const {Pharmacist} = require('../domain/pharmacist')
-const {Plan} = require('../domain/plan')
-const {Prescription} = require('../domain/prescription')
-const {AffiliateRepository} = require('../repositories/affiliateRepository')
-const {InstitutionRepository} = require('../repositories/institutionRepository')
-const {MedicalInsuranceRepository} = require('../repositories/medicalInsuranceRepository')
-const {MedicineRepository} = require('../repositories/medicineRepository')
-const {PrescriptionRepository} = require('../repositories/prescriptions-repository')
-const {DoctorRepository} = require('../repositories/doctorRepository')
-const {PharmacistRepository} = require('../repositories/pharmacistRepository')
-const {logger} = require('../utils/utils')
-const {states} = require('../state-machine/state')
+const { Affiliate } = require('../domain/affiliate')
+const { Doctor } = require('../domain/doctor')
+const { Institution } = require('../domain/institution')
+const { Item } = require('../domain/item')
+const { MedicalInsurance } = require('../domain/medicalInsurance')
+const { Medicine } = require('../domain/medicine')
+const { Pharmacist } = require('../domain/pharmacist')
+const { Plan } = require('../domain/plan')
+const { Prescription } = require('../domain/prescription')
+const { AffiliateRepository } = require('../repositories/affiliateRepository')
+const { InstitutionRepository } = require('../repositories/institutionRepository')
+const { MedicalInsuranceRepository } = require('../repositories/medicalInsuranceRepository')
+const { MedicineRepository } = require('../repositories/medicineRepository')
+const { PrescriptionRepository } = require('../repositories/prescriptions-repository')
+const { DoctorRepository } = require('../repositories/doctorRepository')
+const { PharmacistRepository } = require('../repositories/pharmacistRepository')
+const { logger } = require('../utils/utils')
+const { states } = require('../state-machine/state')
 
 let medicalInsurance1 = new MedicalInsurance()
 medicalInsurance1.address = 'Calle falsa 123'
 medicalInsurance1.contactNumber = '1520202020'
 medicalInsurance1.corporateName = 'OSDE S.R.L.'
-medicalInsurance1.description = "OSDE"
-medicalInsurance1.email = "osde@osde.com"
+medicalInsurance1.description = 'OSDE'
+medicalInsurance1.email = 'osde@osde.com'
 
 let medicalInsurance2 = new MedicalInsurance()
 medicalInsurance2.address = 'Joaquin V Gonzales 1'
 medicalInsurance2.contactNumber = '1520202020'
 medicalInsurance2.corporateName = 'HospitalItaliano S.A.'
-medicalInsurance2.description = "Hospital Italiano"
-medicalInsurance2.email = "hospitalItaliano@hi.com"
+medicalInsurance2.description = 'Hospital Italiano'
+medicalInsurance2.email = 'hospitalItaliano@hi.com'
 
 let medicalInsurance3 = new MedicalInsurance()
 medicalInsurance3.address = 'Beiro 1232'
 medicalInsurance3.contactNumber = '1520202020'
 medicalInsurance3.corporateName = 'OSTEL S.A.'
-medicalInsurance3.description = "OSTEL"
-medicalInsurance3.email = "ostel@ostel.com"
+medicalInsurance3.description = 'OSTEL'
+medicalInsurance3.email = 'ostel@ostel.com'
 
 let medicine1 = new Medicine()
 medicine1.description = 'T4 Montpellier 150 Levotiroxina'
@@ -159,7 +159,7 @@ doctor1.nationality = 'ARGENTINO'
 doctor1.email = 'pepe@medic.com'
 doctor1.address = 'Lo loca 412'
 doctor1.contactNumber = '1520202020'
-doctor1.specialty = {id: 1, description: 'Oncologo'}
+doctor1.specialty = { id: 1, description: 'Oncologo' }
 doctor1.setBirthDate('01/02/1957')
 doctor1.setEntryDate('10/10/2013')
 doctor1.setLeavingDate()
@@ -174,7 +174,7 @@ doctor2.nationality = 'ARGENTINO'
 doctor2.email = 'enrrique@medic.com'
 doctor2.address = 'Otra calle fumeta 8323'
 doctor2.contactNumber = '1520202020'
-doctor2.specialty = {id: 2, description: 'Odontologo'}
+doctor2.specialty = { id: 2, description: 'Odontologo' }
 doctor2.setBirthDate('02/10/1933')
 doctor2.setEntryDate('12/08/2013')
 doctor2.setLeavingDate()
@@ -189,7 +189,7 @@ doctor3.nationality = 'VENEZOLANO'
 doctor3.email = 'rosco@medic.com'
 doctor3.address = 'Menro 932'
 doctor3.contactNumber = '1520202020'
-doctor3.specialty = {id: 3, description: 'Clinico'}
+doctor3.specialty = { id: 3, description: 'Clinico' }
 doctor3.setBirthDate('01/02/1952')
 doctor3.setEntryDate('10/10/2014')
 doctor3.setLeavingDate()
@@ -260,66 +260,65 @@ prescription3.prolongedTreatment = false
 prescription3.setIssuedDate('12/04/2019 15:50')
 
 const generateData = async () => {
-    try {
-
-        medicalInsurance1 = await MedicalInsuranceRepository.create(medicalInsurance1)
-        medicalInsurance2 = await MedicalInsuranceRepository.create(medicalInsurance2)
-        medicalInsurance3 = await MedicalInsuranceRepository.create(medicalInsurance3)
-        medicine1 = await MedicineRepository.create(medicine1)
-        medicine2 = await MedicineRepository.create(medicine2)
-        medicine3 = await MedicineRepository.create(medicine3)
-        institution1 = await InstitutionRepository.create(institution1)
-        institution2 = await InstitutionRepository.create(institution2)
-        institution3 = await InstitutionRepository.create(institution3)
-        institution4 = await InstitutionRepository.create(institution4)
-        institution5 = await InstitutionRepository.create(institution5)
-        affiliate1.plan.idMedicalInsurance = medicalInsurance1.id
-        affiliate2.plan.idMedicalInsurance = medicalInsurance2.id
-        affiliate1 = await AffiliateRepository.create(affiliate1)
-        affiliate2 = await AffiliateRepository.create(affiliate2)
-        doctor1 = await DoctorRepository.create(doctor1)
-        doctor2 = await DoctorRepository.create(doctor2)
-        doctor3 = await DoctorRepository.create(doctor3)
-        pharmacist1 = await PharmacistRepository.create(pharmacist1)
-        pharmacist2 = await PharmacistRepository.create(pharmacist2)
-        pharmacist3 = await PharmacistRepository.create(pharmacist3)
-        prescription1.setMedicalInsurance(medicalInsurance1)
-        prescription1.setAffiliate(affiliate1)
-        prescription1.setDoctor(doctor1)
-        prescription1.setInstitution(institution1)
-        const item1 = new Item()
-        item1.prescribe(2, medicine1)
-        prescription1.addItem(item1)
-        prescription2.setMedicalInsurance(medicalInsurance2)
-        prescription2.setAffiliate(affiliate2)
-        prescription2.setDoctor(doctor2)
-        prescription2.setInstitution(institution2)
-        const item2 = new Item()
-        item2.prescribe(2, medicine2)
-        item2.receive(2, '21/05/2019 13:02', medicine2, pharmacist1)
-        prescription2.addItem(item2)
-        prescription2.setSoldDate('21/05/2019 13:02')
-        prescription3.setMedicalInsurance(medicalInsurance1)
-        prescription3.setAffiliate(affiliate1)
-        prescription3.setDoctor(doctor3)
-        prescription3.setInstitution(institution3)
-        const item3 = new Item()
-        item3.prescribe(1, medicine3)
-        item3.receive(1, '13/04/2019 16:00', medicine3, pharmacist2)
-        item3.audit(1, medicine3)
-        prescription3.addItem(item3)
-        prescription3.setSoldDate('13/04/2019 16:00')
-        prescription3.setAuditedDate('15/04/2019 14:24')
-        prescription1 = await PrescriptionRepository.create(prescription1)
-        prescription2 = await PrescriptionRepository.create(prescription2)
-        prescription3 = await PrescriptionRepository.create(prescription3)
-        logger.info('All mock data generated ok')
-    } catch (error) {
-        logger.error('An error ocurred during mock data generation')
-        logger.error(error)
-    }
+  try {
+    medicalInsurance1 = await MedicalInsuranceRepository.create(medicalInsurance1)
+    medicalInsurance2 = await MedicalInsuranceRepository.create(medicalInsurance2)
+    medicalInsurance3 = await MedicalInsuranceRepository.create(medicalInsurance3)
+    medicine1 = await MedicineRepository.create(medicine1)
+    medicine2 = await MedicineRepository.create(medicine2)
+    medicine3 = await MedicineRepository.create(medicine3)
+    institution1 = await InstitutionRepository.create(institution1)
+    institution2 = await InstitutionRepository.create(institution2)
+    institution3 = await InstitutionRepository.create(institution3)
+    institution4 = await InstitutionRepository.create(institution4)
+    institution5 = await InstitutionRepository.create(institution5)
+    affiliate1.plan.idMedicalInsurance = medicalInsurance1.id
+    affiliate2.plan.idMedicalInsurance = medicalInsurance2.id
+    affiliate1 = await AffiliateRepository.create(affiliate1)
+    affiliate2 = await AffiliateRepository.create(affiliate2)
+    doctor1 = await DoctorRepository.create(doctor1)
+    doctor2 = await DoctorRepository.create(doctor2)
+    doctor3 = await DoctorRepository.create(doctor3)
+    pharmacist1 = await PharmacistRepository.create(pharmacist1)
+    pharmacist2 = await PharmacistRepository.create(pharmacist2)
+    pharmacist3 = await PharmacistRepository.create(pharmacist3)
+    prescription1.setMedicalInsurance(medicalInsurance1)
+    prescription1.setAffiliate(affiliate1)
+    prescription1.setDoctor(doctor1)
+    prescription1.setInstitution(institution1)
+    const item1 = new Item()
+    item1.prescribe(2, medicine1)
+    prescription1.addItem(item1)
+    prescription2.setMedicalInsurance(medicalInsurance2)
+    prescription2.setAffiliate(affiliate2)
+    prescription2.setDoctor(doctor2)
+    prescription2.setInstitution(institution2)
+    const item2 = new Item()
+    item2.prescribe(2, medicine2)
+    item2.receive(2, '21/05/2019 13:02', medicine2, pharmacist1)
+    prescription2.addItem(item2)
+    prescription2.setSoldDate('21/05/2019 13:02')
+    prescription3.setMedicalInsurance(medicalInsurance1)
+    prescription3.setAffiliate(affiliate1)
+    prescription3.setDoctor(doctor3)
+    prescription3.setInstitution(institution3)
+    const item3 = new Item()
+    item3.prescribe(1, medicine3)
+    item3.receive(1, '13/04/2019 16:00', medicine3, pharmacist2)
+    item3.audit(1, medicine3)
+    prescription3.addItem(item3)
+    prescription3.setSoldDate('13/04/2019 16:00')
+    prescription3.setAuditedDate('15/04/2019 14:24')
+    prescription1 = await PrescriptionRepository.create(prescription1)
+    prescription2 = await PrescriptionRepository.create(prescription2)
+    prescription3 = await PrescriptionRepository.create(prescription3)
+    logger.info('All mock data generated ok')
+  } catch (error) {
+    logger.error('An error ocurred during mock data generation')
+    logger.error(error)
+  }
 }
 
 module.exports = {
-    generateData
+  generateData,
 }

--- a/src/codes/entities-codes.js
+++ b/src/codes/entities-codes.js
@@ -1,51 +1,51 @@
 const codes = {
-    PRESCRIPTION: {
-        name: 'prescription',
-        fields: {
-            issuedDate: 'issuedDate',
-            soldDate: 'soldDate',
-            auditedDate: 'auditedDate',
-            prolongedTreatment: 'prolongedTreatment',
-            diagnosis: 'diagnosis',
-            ttl: 'ttl',
-            institution: 'institution',
-            affiliate: 'affiliate',
-            doctor: 'doctor',
-            medicalInsurance: 'medicalInsurance',
-            status: 'status',
-            norm: 'norm',
-            items: 'items'
-        }
+  PRESCRIPTION: {
+    name: 'prescription',
+    fields: {
+      issuedDate: 'issuedDate',
+      soldDate: 'soldDate',
+      auditedDate: 'auditedDate',
+      prolongedTreatment: 'prolongedTreatment',
+      diagnosis: 'diagnosis',
+      ttl: 'ttl',
+      institution: 'institution',
+      affiliate: 'affiliate',
+      doctor: 'doctor',
+      medicalInsurance: 'medicalInsurance',
+      status: 'status',
+      norm: 'norm',
+      items: 'items',
     },
-    AFFILIATE: {
-        name: 'affiliate',
-        fields: {
-            id: 'id'
-        }
+  },
+  AFFILIATE: {
+    name: 'affiliate',
+    fields: {
+      id: 'id',
     },
-    MEDICAL_INSURANCE: {
-        name: 'medicalInsurance',
-        fields: {
-            id: 'id'
-        }
+  },
+  MEDICAL_INSURANCE: {
+    name: 'medicalInsurance',
+    fields: {
+      id: 'id',
     },
-    DOCTOR: {
-        name: 'doctor',
-        fields: {
-            id: 'id'
-        }
+  },
+  DOCTOR: {
+    name: 'doctor',
+    fields: {
+      id: 'id',
     },
-    ITEM: {
-        name: 'items',
-        fields: {
-            prescribed: {
-                quantity: 'prescribed.quantity',
-                medicine: {
-                    id: 'prescribed.medicine.id'
-                }
-            }
-        }
-    }
+  },
+  ITEM: {
+    name: 'items',
+    fields: {
+      prescribed: {
+        quantity: 'prescribed.quantity',
+        medicine: {
+          id: 'prescribed.medicine.id',
+        },
+      },
+    },
+  },
 }
 
-module.exports = {codes}
+module.exports = { codes }

--- a/src/domain/affiliate.js
+++ b/src/domain/affiliate.js
@@ -2,130 +2,131 @@ const { dateFormat } = require('../utils/utils')
 const { Plan } = require('./plan')
 
 class Affiliate {
+  constructor() {
+    this.id = null
+    this.idPatient = null
+    this.name = null
+    this.surname = null
+    this.userName = null
+    this.birthDate = null
+    this.gender = null
+    this.contactNumber = null
+    this.email = null
+    this.address = null
+    this.nationality = null
+    this.nicNumber = null
+    this.nicIssueDate = null
+    this.nicType = null
+    this.nicExemplary = null
+    this.nicPhoto = null
+    this.fromDate = null
+    this.toDate = null
+    this.code = null
+    this.category = null
+    this.imageCredential = null
+    this.plan = new Plan()
+  }
 
-    constructor() {
-        this.id = null
-        this.idPatient = null
-        this.name = null
-        this.surname = null
-        this.userName = null
-        this.birthDate = null
-        this.gender = null
-        this.contactNumber = null
-        this.email = null
-        this.address = null
-        this.nationality = null
-        this.nicNumber = null
-        this.nicIssueDate = null
-        this.nicType = null
-        this.nicExemplary = null
-        this.nicPhoto = null
-        this.fromDate = null
-        this.toDate = null
-        this.code = null
-        this.category = null
-        this.imageCredential = null
-        this.plan = new Plan()
-    }
+  setFromDate(date) {
+    this.fromDate = dateFormat.toDate(date)
+  }
 
-    setFromDate(date) {
-        this.fromDate = dateFormat.toDate(date)
-    }
-    getFromDate() {
-        return dateFormat.toString(this.fromDate)
-    }
+  getFromDate() {
+    return dateFormat.toString(this.fromDate)
+  }
 
-    setToDate(date) {
-        this.toDate = dateFormat.toDate(date)
-    }
-    getToDate() {
-        return dateFormat.toString(this.toDate)
-    }
+  setToDate(date) {
+    this.toDate = dateFormat.toDate(date)
+  }
 
-    setBirthDate(date) {
-        this.birthDate = dateFormat.toDate(date)
-    }
-    getBirthDate() {
-        return dateFormat.toString(this.birthDate)
-    }
+  getToDate() {
+    return dateFormat.toString(this.toDate)
+  }
 
-    setNicIssueDate(date) {
-        this.nicIssueDate = dateFormat.toDate(date)
-    }
-    getNicIssueDate() {
-        return dateFormat.toString(this.nicIssueDate)
-    }
+  setBirthDate(date) {
+    this.birthDate = dateFormat.toDate(date)
+  }
 
-    toJson() {
-        return JSON.stringify({
-            id: this.id,
-            idPatient: this.idPatient,
-            name: this.name,
-            surname: this.surname,
-            userName: this.userName,
-            birthDate: this.getBirthDate(),
-            gender: this.gender,
-            contactNumber: this.contactNumber,
-            email: this.email,
-            address: this.address,
-            nationality: this.nationality,
-            nicNumber: this.nicNumber,
-            nicIssueDate: this.getNicIssueDate(),
-            nicType: this.nicType,
-            nicExemplary: this.nicExemplary,
-            nicPhoto: this.nicPhoto,
-            fromDate: this.getFromDate(),
-            toDate: this.getToDate(),
-            code: this.code,
-            category: this.category,
-            imageCredential: this.imageCredential,
-            plan: this.plan ? JSON.parse(this.plan.toJson()) : this.plan
-        })
+  getBirthDate() {
+    return dateFormat.toString(this.birthDate)
+  }
+
+  setNicIssueDate(date) {
+    this.nicIssueDate = dateFormat.toDate(date)
+  }
+
+  getNicIssueDate() {
+    return dateFormat.toString(this.nicIssueDate)
+  }
+
+  toJson() {
+    return JSON.stringify({
+      id: this.id,
+      idPatient: this.idPatient,
+      name: this.name,
+      surname: this.surname,
+      userName: this.userName,
+      birthDate: this.getBirthDate(),
+      gender: this.gender,
+      contactNumber: this.contactNumber,
+      email: this.email,
+      address: this.address,
+      nationality: this.nationality,
+      nicNumber: this.nicNumber,
+      nicIssueDate: this.getNicIssueDate(),
+      nicType: this.nicType,
+      nicExemplary: this.nicExemplary,
+      nicPhoto: this.nicPhoto,
+      fromDate: this.getFromDate(),
+      toDate: this.getToDate(),
+      code: this.code,
+      category: this.category,
+      imageCredential: this.imageCredential,
+      plan: this.plan ? JSON.parse(this.plan.toJson()) : this.plan,
+    })
+  }
+
+  static fromJson(json = '{}') {
+    if (!json) {
+      return new Affiliate()
     }
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const affiliate = new Affiliate()
+    affiliate.id = object.id || affiliate.id
+    affiliate.idPatient = object.idPatient || affiliate.idPatient
+    affiliate.name = object.name || affiliate.name
+    affiliate.surname = object.surname || affiliate.surname
+    affiliate.userName = object.userName || affiliate.userName
+    affiliate.setBirthDate(object.birthDate)
+    affiliate.gender = object.gender || affiliate.gender
+    affiliate.contactNumber = object.contactNumber || affiliate.contactNumber
+    affiliate.email = object.email || affiliate.email
+    affiliate.address = object.address || affiliate.address
+    affiliate.nationality = object.nationality || affiliate.nationality
+    affiliate.nicNumber = object.nicNumber || affiliate.nicNumber
+    affiliate.setNicIssueDate(object.nicIssueDate)
+    affiliate.nicType = object.nicType || affiliate.nicType
+    affiliate.nicExemplary = object.nicExemplary || affiliate.nicExemplary
+    affiliate.nicPhoto = object.nicPhoto || affiliate.nicPhoto
+    affiliate.setFromDate(object.fromDate)
+    affiliate.setToDate(object.toDate)
+    affiliate.code = object.code || affiliate.code
+    affiliate.category = object.category || affiliate.category
+    affiliate.imageCredential = object.imageCredential || affiliate.imageCredential
+    affiliate.plan = Plan.fromJson(object.plan)
+    return affiliate
+  }
 
-    static fromJson(json = '{}') {
-        if (!json) {
-            return new Affiliate()
-        }
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const affiliate = new Affiliate()
-        affiliate.id = object.id || affiliate.id
-        affiliate.idPatient = object.idPatient || affiliate.idPatient
-        affiliate.name = object.name || affiliate.name
-        affiliate.surname = object.surname || affiliate.surname
-        affiliate.userName = object.userName || affiliate.userName
-        affiliate.setBirthDate(object.birthDate)
-        affiliate.gender = object.gender || affiliate.gender
-        affiliate.contactNumber = object.contactNumber || affiliate.contactNumber
-        affiliate.email = object.email || affiliate.email
-        affiliate.address = object.address || affiliate.address
-        affiliate.nationality = object.nationality || affiliate.nationality
-        affiliate.nicNumber = object.nicNumber || affiliate.nicNumber
-        affiliate.setNicIssueDate(object.nicIssueDate)
-        affiliate.nicType = object.nicType || affiliate.nicType
-        affiliate.nicExemplary = object.nicExemplary || affiliate.nicExemplary
-        affiliate.nicPhoto = object.nicPhoto || affiliate.nicPhoto
-        affiliate.setFromDate(object.fromDate)
-        affiliate.setToDate(object.toDate)
-        affiliate.code = object.code || affiliate.code
-        affiliate.category = object.category || affiliate.category
-        affiliate.imageCredential = object.imageCredential || affiliate.imageCredential
-        affiliate.plan = Plan.fromJson(object.plan)
-        return affiliate
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
 
+  static fromObject(object) {
+    if (!(object instanceof Affiliate)) {
+      return Affiliate.fromJson(object)
     }
-
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
-
-    static fromObject(object) {
-        if (!(object instanceof Affiliate)) {
-            return Affiliate.fromJson(object)
-        }
-        return object
-    }
-
+    return object
+  }
 }
 
 module.exports = { Affiliate }

--- a/src/domain/doctor.js
+++ b/src/domain/doctor.js
@@ -1,99 +1,98 @@
 const { dateFormat } = require('../utils/utils')
 
 class Doctor {
+  constructor() {
+    this.id = null
+    this.name = null
+    this.lastName = null
+    this.userName = null
+    this.birthDate = null
+    this.entryDate = null
+    this.leavingDate = null
+    this.contactNumber = null
+    this.nationality = null
+    this.address = null
+    this.email = null
+    this.nationalMatriculation = null
+    this.provincialMatriculation = null
+    this.specialty = null
+  }
 
-    constructor() {
-        this.id = null
-        this.name = null
-        this.lastName = null
-        this.userName = null
-        this.birthDate = null
-        this.entryDate = null
-        this.leavingDate = null
-        this.contactNumber = null
-        this.nationality = null
-        this.address = null
-        this.email = null
-        this.nationalMatriculation = null
-        this.provincialMatriculation = null
-        this.specialty = null
-    }
+  setBirthDate(date) {
+    this.birthDate = dateFormat.toDate(date)
+  }
 
-    setBirthDate(date) {
-        this.birthDate = dateFormat.toDate(date)
-    }
+  getBirthDate() {
+    return dateFormat.toString(this.birthDate)
+  }
 
-    getBirthDate() {
-        return dateFormat.toString(this.birthDate)
-    }
+  setEntryDate(date) {
+    this.entryDate = dateFormat.toDate(date)
+  }
 
-    setEntryDate(date) {
-        this.entryDate = dateFormat.toDate(date)
-    }
-    getEntryDate() {
-        return dateFormat.toString(this.entryDate)
-    }
+  getEntryDate() {
+    return dateFormat.toString(this.entryDate)
+  }
 
-    setLeavingDate(date) {
-        this.leavingDate = dateFormat.toDate(date)
-    }
+  setLeavingDate(date) {
+    this.leavingDate = dateFormat.toDate(date)
+  }
 
-    getLeavingDate() {
-        return dateFormat.toString(this.leavingDate)
-    }
+  getLeavingDate() {
+    return dateFormat.toString(this.leavingDate)
+  }
 
-    toJson() {
-        return JSON.stringify({
-            id: this.id,
-            name: this.name,
-            lastName: this.lastName,
-            userName: this.userName,
-            birthDate: this.getBirthDate(),
-            entryDate: this.getEntryDate(),
-            leavingDate: this.getLeavingDate(),
-            contactNumber: this.contactNumber,
-            nationality: this.nationality,
-            address: this.address,
-            email: this.email,
-            nationalMatriculation: this.nationalMatriculation,
-            provincialMatriculation: this.provincialMatriculation,
-            specialty: this.specialty
-        })
-    }
+  toJson() {
+    return JSON.stringify({
+      id: this.id,
+      name: this.name,
+      lastName: this.lastName,
+      userName: this.userName,
+      birthDate: this.getBirthDate(),
+      entryDate: this.getEntryDate(),
+      leavingDate: this.getLeavingDate(),
+      contactNumber: this.contactNumber,
+      nationality: this.nationality,
+      address: this.address,
+      email: this.email,
+      nationalMatriculation: this.nationalMatriculation,
+      provincialMatriculation: this.provincialMatriculation,
+      specialty: this.specialty,
+    })
+  }
 
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
 
-    static fromJson(json = '{}') {
-        if (!json){
-            return new Doctor()
-        }
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const doctor = new Doctor()
-        doctor.id = object.id || doctor.id
-        doctor.setBirthDate (object.birthDate) 
-        doctor.setEntryDate ( object.entryDate) 
-        doctor.setLeavingDate( object.leavingDate)
-        doctor.name = object.name || doctor.name
-        doctor.lastName = object.lastName || doctor.lastName
-        doctor.userName = object.userName || doctor.userName
-        doctor.contactNumber = object.contactNumber || doctor.contactNumber
-        doctor.nationality = object.nationality || doctor.nationality
-        doctor.address = object.address || doctor.address
-        doctor.email = object.email || doctor.email
-        doctor.nationalMatriculation = object.nationalMatriculation || doctor.nationalMatriculation
-        doctor.provincialMatriculation = object.provincialMatriculation || doctor.provincialMatriculation
-        doctor.specialty = object.specialty || doctor.specialty
-        return doctor
+  static fromJson(json = '{}') {
+    if (!json) {
+      return new Doctor()
     }
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const doctor = new Doctor()
+    doctor.id = object.id || doctor.id
+    doctor.setBirthDate(object.birthDate)
+    doctor.setEntryDate(object.entryDate)
+    doctor.setLeavingDate(object.leavingDate)
+    doctor.name = object.name || doctor.name
+    doctor.lastName = object.lastName || doctor.lastName
+    doctor.userName = object.userName || doctor.userName
+    doctor.contactNumber = object.contactNumber || doctor.contactNumber
+    doctor.nationality = object.nationality || doctor.nationality
+    doctor.address = object.address || doctor.address
+    doctor.email = object.email || doctor.email
+    doctor.nationalMatriculation = object.nationalMatriculation || doctor.nationalMatriculation
+    doctor.provincialMatriculation = object.provincialMatriculation || doctor.provincialMatriculation
+    doctor.specialty = object.specialty || doctor.specialty
+    return doctor
+  }
 
-    static fromObject(object){
-        if (!(object instanceof Doctor)){
-            return Doctor.fromJson(object)
-        }
-        return object 
+  static fromObject(object) {
+    if (!(object instanceof Doctor)) {
+      return Doctor.fromJson(object)
     }
-
+    return object
+  }
 }
 module.exports = { Doctor }

--- a/src/domain/institution.js
+++ b/src/domain/institution.js
@@ -1,40 +1,40 @@
 class Institution {
-    constructor(){
-        this.id = null
-        this.description = null
-        this.address = null
-    }
+  constructor() {
+    this.id = null
+    this.description = null
+    this.address = null
+  }
 
-    toJson() {
-        return JSON.stringify({
-            id: this.id,
-            description: this.description,
-            address: this.address
-        })
-    }
+  toJson() {
+    return JSON.stringify({
+      id: this.id,
+      description: this.description,
+      address: this.address,
+    })
+  }
 
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
 
-    static fromJson(json = '{}') {
-        if (!json){
-            return new Institution()
-        }
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const institution = new Institution()
-        institution.id = object.id || institution.id
-        institution.description = object.description || institution.description
-        institution.address = object.address  || institution.address
-        return institution
+  static fromJson(json = '{}') {
+    if (!json) {
+      return new Institution()
     }
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const institution = new Institution()
+    institution.id = object.id || institution.id
+    institution.description = object.description || institution.description
+    institution.address = object.address || institution.address
+    return institution
+  }
 
-    static fromObject(object){
-        if (!(object instanceof Institution)){
-            return Institution.fromJson(object)
-        }
-        return object 
+  static fromObject(object) {
+    if (!(object instanceof Institution)) {
+      return Institution.fromJson(object)
     }
+    return object
+  }
 }
 
 module.exports = { Institution }

--- a/src/domain/item.js
+++ b/src/domain/item.js
@@ -1,109 +1,111 @@
 const { dateTimeFormat } = require('../utils/utils')
 
 class Item {
-    constructor() {
-        this.id = null
-        this.prescribed = {
-            quantity: null,
-            medicine: {
-                id: null
-            }
-        }
-        this.received = {
-            quantity: null,
-            soldDate: null,
-            medicine: {
-                id: null
-            },
-            pharmacist: {
-                id: null
-            }
-        }
-        this.audited = {
-            quantity: null,
-            medicine: {
-                id: null
-            }
-        }
+  constructor() {
+    this.id = null
+    this.prescribed = {
+      quantity: null,
+      medicine: {
+        id: null,
+      },
     }
-    prescribe(quantity, medicine) {
-        this.prescribed = {
-            quantity,
-            medicine
-        }
+    this.received = {
+      quantity: null,
+      soldDate: null,
+      medicine: {
+        id: null,
+      },
+      pharmacist: {
+        id: null,
+      },
     }
+    this.audited = {
+      quantity: null,
+      medicine: {
+        id: null,
+      },
+    }
+  }
 
-    receive(quantity, soldDate, medicine, pharmacist) {
-        this.received = {
-            quantity,
-            soldDate: dateTimeFormat.toDate(soldDate),
-            medicine,
-            pharmacist
-        }
+  prescribe(quantity, medicine) {
+    this.prescribed = {
+      quantity,
+      medicine,
     }
+  }
+
+  receive(quantity, soldDate, medicine, pharmacist) {
+    this.received = {
+      quantity,
+      soldDate: dateTimeFormat.toDate(soldDate),
+      medicine,
+      pharmacist,
+    }
+  }
 
 
-    audit(quantity, medicine) {
-        this.audited = {
-            quantity,
-            medicine
-        }
+  audit(quantity, medicine) {
+    this.audited = {
+      quantity,
+      medicine,
     }
+  }
 
-    getSoldDate() {
-        return dateTimeFormat.toString(this.received.soldDate)
-    }
+  getSoldDate() {
+    return dateTimeFormat.toString(this.received.soldDate)
+  }
 
-    toJson() {
-        return JSON.stringify(
-            {
-                id: this.id,
-                prescribed: {
-                    quantity: this.prescribed.quantity,
-                    medicine: this.prescribed.medicine
-                },
-                received: {
-                    quantity: this.received.quantity,
-                    soldDate: this.getSoldDate(),
-                    medicine: this.received.medicine,
-                    pharmacist: this.received.pharmacist
-                },
-                audited: {
-                    quantity: this.audited.quantity,
-                    medicine: this.audited.medicine
-                }
-            })
-    }
+  toJson() {
+    return JSON.stringify(
+      {
+        id: this.id,
+        prescribed: {
+          quantity: this.prescribed.quantity,
+          medicine: this.prescribed.medicine,
+        },
+        received: {
+          quantity: this.received.quantity,
+          soldDate: this.getSoldDate(),
+          medicine: this.received.medicine,
+          pharmacist: this.received.pharmacist,
+        },
+        audited: {
+          quantity: this.audited.quantity,
+          medicine: this.audited.medicine,
+        },
+      },
+    )
+  }
 
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
 
-    static fromJson(json) {
-        if (!json) {
-            return new Item()
-        }
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const item = new Item()
-        item.id = object.id || item.id
-        const { prescribed, received, audited } = object
-        item.prescribe(prescribed && prescribed.quantity || item.prescribed.quantity,
-            object.prescribed.medicine || item.prescribed.medicine)
-        const soldDate = received && received.soldDate || item.received.soldDate
-        item.receive(object.received && received.quantity || item.received.quantity,
-            dateTimeFormat.toDate(soldDate),
-            received && received.medicine || item.received.medicine,
-            received && received.pharmacist || item.received.pharmacist)
-        item.audit(audited && audited.quantity || item.audited.quantity, audited && audited.medicine || item.audited.medicine)
-        return item
+  static fromJson(json) {
+    if (!json) {
+      return new Item()
     }
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const item = new Item()
+    item.id = object.id || item.id
+    const { prescribed, received, audited } = object
+    item.prescribe(prescribed && prescribed.quantity || item.prescribed.quantity,
+      object.prescribed.medicine || item.prescribed.medicine)
+    const soldDate = received && received.soldDate || item.received.soldDate
+    item.receive(object.received && received.quantity || item.received.quantity,
+      dateTimeFormat.toDate(soldDate),
+      received && received.medicine || item.received.medicine,
+      received && received.pharmacist || item.received.pharmacist)
+    item.audit(audited && audited.quantity || item.audited.quantity, audited && audited.medicine || item.audited.medicine)
+    return item
+  }
 
-    static fromObject(object) {
-        if (!(object instanceof Item)) {
-            return Item.fromJson(object)
-        }
-        return object
+  static fromObject(object) {
+    if (!(object instanceof Item)) {
+      return Item.fromJson(object)
     }
+    return object
+  }
 }
 
 module.exports = { Item }

--- a/src/domain/medicalInsurance.js
+++ b/src/domain/medicalInsurance.js
@@ -1,52 +1,51 @@
 class MedicalInsurance {
-    constructor() {
-        this.id = null
-        this.description = null
-        this.userName = null
-        this.corporateName = null
-        this.email = null
-        this.address = null
-        this.contactNumber = null
-    }
+  constructor() {
+    this.id = null
+    this.description = null
+    this.userName = null
+    this.corporateName = null
+    this.email = null
+    this.address = null
+    this.contactNumber = null
+  }
 
-    toJson() {
-        return JSON.stringify({
-            id: this.id,
-            description: this.description,
-            userName: this.userName,
-            corporateName: this.corporateName,
-            email: this.email,
-            address: this.address,
-            contactNumber: this.contactNumber
-        })
-    }
+  toJson() {
+    return JSON.stringify({
+      id: this.id,
+      description: this.description,
+      userName: this.userName,
+      corporateName: this.corporateName,
+      email: this.email,
+      address: this.address,
+      contactNumber: this.contactNumber,
+    })
+  }
 
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
 
-    static fromJson(json = '{}') {
-        if (!json){
-            return new MedicalInsurance()
-        }
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const medicalInsurance = new MedicalInsurance()
-        medicalInsurance.id = object.id || medicalInsurance.id
-        medicalInsurance.description = object.description || medicalInsurance.description
-        medicalInsurance.userName = object.userName || medicalInsurance.userName
-        medicalInsurance.corporateName = object.corporateName || medicalInsurance.corporateName
-        medicalInsurance.email = object.email || medicalInsurance.email
-        medicalInsurance.address = object.address || medicalInsurance.address
-        medicalInsurance.contactNumber = object.contactNumber || medicalInsurance.contactNumber
-        return medicalInsurance
+  static fromJson(json = '{}') {
+    if (!json) {
+      return new MedicalInsurance()
     }
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const medicalInsurance = new MedicalInsurance()
+    medicalInsurance.id = object.id || medicalInsurance.id
+    medicalInsurance.description = object.description || medicalInsurance.description
+    medicalInsurance.userName = object.userName || medicalInsurance.userName
+    medicalInsurance.corporateName = object.corporateName || medicalInsurance.corporateName
+    medicalInsurance.email = object.email || medicalInsurance.email
+    medicalInsurance.address = object.address || medicalInsurance.address
+    medicalInsurance.contactNumber = object.contactNumber || medicalInsurance.contactNumber
+    return medicalInsurance
+  }
 
-    static fromObject(object){
-        if (!(object instanceof MedicalInsurance)){
-            return MedicalInsurance.fromJson(object)
-        }
-        return object 
+  static fromObject(object) {
+    if (!(object instanceof MedicalInsurance)) {
+      return MedicalInsurance.fromJson(object)
     }
-
+    return object
+  }
 }
 module.exports = { MedicalInsurance }

--- a/src/domain/medicine.js
+++ b/src/domain/medicine.js
@@ -1,84 +1,84 @@
 const { dateFormat } = require('../utils/utils')
 
 class Medicine {
-    constructor() {
-        this.id = null
-        this.description = null
-        this.troquel = null
-        this.pharmaceuticalAction = null
-        this.entryDate = null
-        this.leavingDate = null
-        this.barCode = null
-        this.brandDescription = null
-        this.sizeDescription = null
-        this.presentationDescription = null
-        this.drugDescription = null
-        this.laboratoryDescription = null
-        this.potencyDescription = null
-    }
+  constructor() {
+    this.id = null
+    this.description = null
+    this.troquel = null
+    this.pharmaceuticalAction = null
+    this.entryDate = null
+    this.leavingDate = null
+    this.barCode = null
+    this.brandDescription = null
+    this.sizeDescription = null
+    this.presentationDescription = null
+    this.drugDescription = null
+    this.laboratoryDescription = null
+    this.potencyDescription = null
+  }
 
-    setEntryDate(date) {
-        this.entryDate = dateFormat.toDate(date)
-    }
-    
-    getEntryDate() {
-        return dateFormat.toString(this.entryDate)
-    }
+  setEntryDate(date) {
+    this.entryDate = dateFormat.toDate(date)
+  }
 
-    setLeavingDate(date) {
-        this.leavingDate = dateFormat.toDate(date)
-    }
-    
-    getLeavingDate() {
-        return dateFormat.toString(this.leavingDate)
-    }
+  getEntryDate() {
+    return dateFormat.toString(this.entryDate)
+  }
 
-    toJson() {
-        return JSON.stringify({
-            id: this.id,
-            description: this.description,
-            troquel: this.troquel,
-            pharmaceuticalAction: this.pharmaceuticalAction,
-            entryDate: this.getEntryDate(),
-            leavingDate: this.getLeavingDate(),
-            barCode: this.barCode,
-            brandDescription: this.brandDescription,
-            sizeDescription: this.sizeDescription,
-            presentationDescription: this.presentationDescription,
-            drugDescription: this.drugDescription,
-            laboratoryDescription: this.laboratoryDescription,
-            potencyDescription: this.potencyDescription
-        })
-    }
+  setLeavingDate(date) {
+    this.leavingDate = dateFormat.toDate(date)
+  }
 
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
+  getLeavingDate() {
+    return dateFormat.toString(this.leavingDate)
+  }
 
-    static fromJson(json = '{}') {
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const medicine = new Medicine()
-        medicine.id = object.id || medicine.id
-        medicine.description = object.description || medicine.id
-        medicine.troquel = object.troquel || medicine.troquel
-        medicine.pharmaceuticalAction = object.pharmaceuticalAction || medicine.pharmaceuticalAction
-        medicine.setEntryDate(object.entryDate)
-        medicine.setLeavingDate(object.leavingDate)
-        medicine.barCode = object.barCode || medicine.barCode
-        medicine.brandDescription = object.brandDescription || medicine.brandDescription
-        medicine.sizeDescription = object.sizeDescription || medicine.sizeDescription
-        medicine.presentationDescription = object.presentationDescription || medicine.presentationDescription
-        medicine.drugDescription = object.drugDescription || medicine.drugDescription
-        medicine.laboratoryDescription = object.laboratoryDescription || medicine.laboratoryDescription
-        medicine.potencyDescription = object.potencyDescription || medicine.potencyDescription
-        return medicine
-    }
+  toJson() {
+    return JSON.stringify({
+      id: this.id,
+      description: this.description,
+      troquel: this.troquel,
+      pharmaceuticalAction: this.pharmaceuticalAction,
+      entryDate: this.getEntryDate(),
+      leavingDate: this.getLeavingDate(),
+      barCode: this.barCode,
+      brandDescription: this.brandDescription,
+      sizeDescription: this.sizeDescription,
+      presentationDescription: this.presentationDescription,
+      drugDescription: this.drugDescription,
+      laboratoryDescription: this.laboratoryDescription,
+      potencyDescription: this.potencyDescription,
+    })
+  }
 
-    static fromObject(object){
-        if (!(object instanceof Medicine)){
-            return Medicine.fromJson(object)
-        }
-        return object 
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
+
+  static fromJson(json = '{}') {
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const medicine = new Medicine()
+    medicine.id = object.id || medicine.id
+    medicine.description = object.description || medicine.id
+    medicine.troquel = object.troquel || medicine.troquel
+    medicine.pharmaceuticalAction = object.pharmaceuticalAction || medicine.pharmaceuticalAction
+    medicine.setEntryDate(object.entryDate)
+    medicine.setLeavingDate(object.leavingDate)
+    medicine.barCode = object.barCode || medicine.barCode
+    medicine.brandDescription = object.brandDescription || medicine.brandDescription
+    medicine.sizeDescription = object.sizeDescription || medicine.sizeDescription
+    medicine.presentationDescription = object.presentationDescription || medicine.presentationDescription
+    medicine.drugDescription = object.drugDescription || medicine.drugDescription
+    medicine.laboratoryDescription = object.laboratoryDescription || medicine.laboratoryDescription
+    medicine.potencyDescription = object.potencyDescription || medicine.potencyDescription
+    return medicine
+  }
+
+  static fromObject(object) {
+    if (!(object instanceof Medicine)) {
+      return Medicine.fromJson(object)
     }
+    return object
+  }
 }
 module.exports = { Medicine }

--- a/src/domain/pharmacist.js
+++ b/src/domain/pharmacist.js
@@ -1,93 +1,92 @@
 const { dateFormat } = require('../utils/utils')
 
 class Pharmacist {
+  constructor() {
+    this.id = null
+    this.name = null
+    this.lastName = null
+    this.userName = null
+    this.birthDate = null
+    this.entryDate = null
+    this.leavingDate = null
+    this.contactNumber = null
+    this.nationality = null
+    this.address = null
+    this.email = null
+    this.matriculation = null
+  }
 
-    constructor() {
-        this.id = null
-        this.name = null
-        this.lastName = null
-        this.userName = null
-        this.birthDate = null
-        this.entryDate = null
-        this.leavingDate = null
-        this.contactNumber = null
-        this.nationality = null
-        this.address = null
-        this.email = null
-        this.matriculation = null
-    }
+  setBirthDate(date) {
+    this.birthDate = dateFormat.toDate(date)
+  }
 
-    setBirthDate(date) {
-        this.birthDate = dateFormat.toDate(date)
-    }
-    
-    getBirthDate() {
-        return dateFormat.toString(this.birthDate)
-    }
+  getBirthDate() {
+    return dateFormat.toString(this.birthDate)
+  }
 
-    setEntryDate(date) {
-        this.entryDate = dateFormat.toDate(date)
-    }
-    getEntryDate() {
-        return dateFormat.toString(this.entryDate)
-    }
+  setEntryDate(date) {
+    this.entryDate = dateFormat.toDate(date)
+  }
 
-    setLeavingDate(date) {
-        this.leavingDate = dateFormat.toDate(date)
-    }
+  getEntryDate() {
+    return dateFormat.toString(this.entryDate)
+  }
 
-    getLeavingDate() {
-        return dateFormat.toString(this.leavingDate)
-    }
+  setLeavingDate(date) {
+    this.leavingDate = dateFormat.toDate(date)
+  }
 
-    toJson() {
-        return JSON.stringify({
-            id: this.id,
-            name: this.name,
-            lastName: this.lastName,
-            userName: this.userName,
-            birthDate: this.getBirthDate(),
-            entryDate: this.getEntryDate(),
-            leavingDate: this.getLeavingDate(),
-            contactNumber: this.contactNumber,
-            nationality: this.nationality,
-            address: this.address,
-            email: this.email,
-            matriculation: this.matriculation
-        })
-    }
+  getLeavingDate() {
+    return dateFormat.toString(this.leavingDate)
+  }
 
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
+  toJson() {
+    return JSON.stringify({
+      id: this.id,
+      name: this.name,
+      lastName: this.lastName,
+      userName: this.userName,
+      birthDate: this.getBirthDate(),
+      entryDate: this.getEntryDate(),
+      leavingDate: this.getLeavingDate(),
+      contactNumber: this.contactNumber,
+      nationality: this.nationality,
+      address: this.address,
+      email: this.email,
+      matriculation: this.matriculation,
+    })
+  }
 
-    static fromJson(json = '{}') {
-        if (!json){
-            return new Doctor()
-        }
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const pharmacist = new Pharmacist()
-        pharmacist.id = object.id || pharmacist.id
-        pharmacist.setBirthDate (object.birthDate) 
-        pharmacist.setEntryDate ( object.entryDate) 
-        pharmacist.setLeavingDate( object.leavingDate)
-        pharmacist.name = object.name || pharmacist.name
-        pharmacist.lastName = object.lastName || pharmacist.lastName
-        pharmacist.userName = object.userName || pharmacist.userName
-        pharmacist.contactNumber = object.contactNumber || pharmacist.contactNumber
-        pharmacist.nationality = object.nationality || pharmacist.nationality
-        pharmacist.address = object.address || pharmacist.address
-        pharmacist.email = object.email || pharmacist.email
-        pharmacist.matriculation = object.matriculation || pharmacist.matriculation
-        return pharmacist
-    }
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
 
-    static fromObject(object){
-        if (!(object instanceof Pharmacist)){
-            return Pharmacist.fromJson(object)
-        }
-        return object 
+  static fromJson(json = '{}') {
+    if (!json) {
+      return new Doctor()
     }
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const pharmacist = new Pharmacist()
+    pharmacist.id = object.id || pharmacist.id
+    pharmacist.setBirthDate(object.birthDate)
+    pharmacist.setEntryDate(object.entryDate)
+    pharmacist.setLeavingDate(object.leavingDate)
+    pharmacist.name = object.name || pharmacist.name
+    pharmacist.lastName = object.lastName || pharmacist.lastName
+    pharmacist.userName = object.userName || pharmacist.userName
+    pharmacist.contactNumber = object.contactNumber || pharmacist.contactNumber
+    pharmacist.nationality = object.nationality || pharmacist.nationality
+    pharmacist.address = object.address || pharmacist.address
+    pharmacist.email = object.email || pharmacist.email
+    pharmacist.matriculation = object.matriculation || pharmacist.matriculation
+    return pharmacist
+  }
 
+  static fromObject(object) {
+    if (!(object instanceof Pharmacist)) {
+      return Pharmacist.fromJson(object)
+    }
+    return object
+  }
 }
 module.exports = { Pharmacist }

--- a/src/domain/plan.js
+++ b/src/domain/plan.js
@@ -1,56 +1,56 @@
 const { dateFormat } = require('../utils/utils')
 
 class Plan {
+  constructor() {
+    this.id = null
+    this.description = null
+    this.entryDate = null
+    this.leavingDate = null
+    this.percentage = null
+    this.idMedicalInsurance = null
+  }
 
-    constructor() {
-        this.id = null
-        this.description = null
-        this.entryDate = null
-        this.leavingDate = null
-        this.percentage = null
-        this.idMedicalInsurance = null
-    }
+  setEntryDate(date) {
+    this.entryDate = dateFormat.toDate(date)
+  }
 
-    setEntryDate(date) {
-        this.entryDate = dateFormat.toDate(date)
-    }
-    getEntryDate() {
-        return dateFormat.toString(this.entryDate)
-    }
+  getEntryDate() {
+    return dateFormat.toString(this.entryDate)
+  }
 
-    setLeavingDate(date) {
-        this.leavingDate = dateFormat.toDate(date)
-    }
-    getLeavingDate() {
-        return dateFormat.toString(this.leavingDate)
-    }
+  setLeavingDate(date) {
+    this.leavingDate = dateFormat.toDate(date)
+  }
 
-    toJson() {
-        return JSON.stringify({
-            id: this.id,
-            description: this.description,
-            entryDate: this.getEntryDate(),
-            leavingDate: this.getLeavingDate(),
-            percentage: this.percentage,
-            idMedicalInsurance: this.idMedicalInsurance
-        })
-    }
+  getLeavingDate() {
+    return dateFormat.toString(this.leavingDate)
+  }
 
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
+  toJson() {
+    return JSON.stringify({
+      id: this.id,
+      description: this.description,
+      entryDate: this.getEntryDate(),
+      leavingDate: this.getLeavingDate(),
+      percentage: this.percentage,
+      idMedicalInsurance: this.idMedicalInsurance,
+    })
+  }
 
-    static fromJson(json = '{}') {
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const plan = new Plan()
-        plan.id = object.id || plan.id
-        plan.description = object.description || plan.description
-        plan.setEntryDate(object.entryDate)
-        plan.setLeavingDate(object.leavingDate)
-        plan.percentage = object.percentage || plan.percentage
-        plan.idMedicalInsurance = object.idMedicalInsurance || plan.idMedicalInsurance
-        return plan
-    }
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
 
+  static fromJson(json = '{}') {
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const plan = new Plan()
+    plan.id = object.id || plan.id
+    plan.description = object.description || plan.description
+    plan.setEntryDate(object.entryDate)
+    plan.setLeavingDate(object.leavingDate)
+    plan.percentage = object.percentage || plan.percentage
+    plan.idMedicalInsurance = object.idMedicalInsurance || plan.idMedicalInsurance
+    return plan
+  }
 }
 module.exports = { Plan }

--- a/src/domain/prescription.js
+++ b/src/domain/prescription.js
@@ -1,130 +1,130 @@
-const {dateTimeFormat} = require('../utils/utils')
-const {Institution} = require('../domain/institution')
-const {Doctor} = require('../domain/doctor')
-const {MedicalInsurance} = require('../domain/medicalInsurance')
-const {Affiliate} = require('../domain/affiliate')
-const {Item} = require('../domain/item')
+const { dateTimeFormat } = require('../utils/utils')
+const { Institution } = require('../domain/institution')
+const { Doctor } = require('../domain/doctor')
+const { MedicalInsurance } = require('../domain/medicalInsurance')
+const { Affiliate } = require('../domain/affiliate')
+const { Item } = require('../domain/item')
 
 class Prescription {
-    constructor(){
-        this.id = null
-        this.issuedDate = null
-        this.soldDate = null
-        this.auditedDate = null
-        this.prolongedTreatment = false
-        this.diagnosis = null
-        this.ttl = null
-        this.institution = null
-        this.affiliate = null
-        this.doctor = null
-        this.medicalInsurance = null
-        this.status = null
-        this.norm = null
-        this.items = []
-    }
+  constructor() {
+    this.id = null
+    this.issuedDate = null
+    this.soldDate = null
+    this.auditedDate = null
+    this.prolongedTreatment = false
+    this.diagnosis = null
+    this.ttl = null
+    this.institution = null
+    this.affiliate = null
+    this.doctor = null
+    this.medicalInsurance = null
+    this.status = null
+    this.norm = null
+    this.items = []
+  }
 
-    addItem(item){
-        this.items.push(Item.fromObject(item))
-    }
+  addItem(item) {
+    this.items.push(Item.fromObject(item))
+  }
 
-    setIssuedDate(date){
-        this.issuedDate = dateTimeFormat.toDate(date)
-    }
+  setIssuedDate(date) {
+    this.issuedDate = dateTimeFormat.toDate(date)
+  }
 
-    getIssuedDate(){
-        return dateTimeFormat.toString(this.issuedDate)
-    }
+  getIssuedDate() {
+    return dateTimeFormat.toString(this.issuedDate)
+  }
 
-    setSoldDate(date){
-        this.soldDate = dateTimeFormat.toDate(date)
-    }
+  setSoldDate(date) {
+    this.soldDate = dateTimeFormat.toDate(date)
+  }
 
-    getSoldDate(){
-        return dateTimeFormat.toString(this.soldDate)
-    }
+  getSoldDate() {
+    return dateTimeFormat.toString(this.soldDate)
+  }
 
-    setAuditedDate(date){
-        this.auditedDate = dateTimeFormat.toDate(date)
-    }
+  setAuditedDate(date) {
+    this.auditedDate = dateTimeFormat.toDate(date)
+  }
 
-    getAuditedDate(){
-        return dateTimeFormat.toString(this.auditedDate)
-    }
+  getAuditedDate() {
+    return dateTimeFormat.toString(this.auditedDate)
+  }
 
-    setInstitution(institution){
-        this.institution = Institution.fromObject(institution)
-    }
+  setInstitution(institution) {
+    this.institution = Institution.fromObject(institution)
+  }
 
-    setDoctor(doctor){
-        this.doctor = Doctor.fromObject(doctor)
-    }
+  setDoctor(doctor) {
+    this.doctor = Doctor.fromObject(doctor)
+  }
 
-    setMedicalInsurance(medicalInsurance){
-        this.medicalInsurance = MedicalInsurance.fromObject(medicalInsurance)
-    }
+  setMedicalInsurance(medicalInsurance) {
+    this.medicalInsurance = MedicalInsurance.fromObject(medicalInsurance)
+  }
 
-    setAffiliate(affiliate){
-        this.affiliate = Affiliate.fromObject(affiliate)
-    }
+  setAffiliate(affiliate) {
+    this.affiliate = Affiliate.fromObject(affiliate)
+  }
 
-    toJson(){
-        return JSON.stringify({
-            id: this.id,
-            issuedDate: this.getIssuedDate(),
-            soldDate: this.getSoldDate(),
-            auditedDate: this.getAuditedDate(),
-            prolongedTreatment: this.prolongedTreatment,
-            diagnosis: this.diagnosis,
-            ttl: this.ttl,
-            institution: this.institution && this.institution.toPlainObject(),
-            affiliate: this.affiliate && this.affiliate.toPlainObject(),
-            doctor: this.doctor && this.doctor.toPlainObject(),
-            medicalInsurance: this.medicalInsurance && this.medicalInsurance.toPlainObject(),
-            status: this.status,
-            norm: this.norm,
-            items: this.items.length ? this.items.map(item => item.toPlainObject()) : this.items
-        })
-    }
+  toJson() {
+    return JSON.stringify({
+      id: this.id,
+      issuedDate: this.getIssuedDate(),
+      soldDate: this.getSoldDate(),
+      auditedDate: this.getAuditedDate(),
+      prolongedTreatment: this.prolongedTreatment,
+      diagnosis: this.diagnosis,
+      ttl: this.ttl,
+      institution: this.institution && this.institution.toPlainObject(),
+      affiliate: this.affiliate && this.affiliate.toPlainObject(),
+      doctor: this.doctor && this.doctor.toPlainObject(),
+      medicalInsurance: this.medicalInsurance && this.medicalInsurance.toPlainObject(),
+      status: this.status,
+      norm: this.norm,
+      items: this.items.length ? this.items.map(item => item.toPlainObject()) : this.items,
+    })
+  }
 
-    toPlainObject(){
-        return JSON.parse(this.toJson())
-    }
+  toPlainObject() {
+    return JSON.parse(this.toJson())
+  }
 
-    static fromJson(json = '{}'){
-        if (!json){
-            return new Prescription()
-        }
-        let object = typeof json === 'object' ? json : JSON.parse(json)
-        const prescription = new Prescription()
-        prescription.id = object.id || prescription.id
-        prescription.setIssuedDate(object.issuedDate)
-        prescription.setSoldDate(object.soldDate)
-        prescription.setAuditedDate(object.auditedDate)
-        prescription.prolongedTreatment = object.prolongedTreatment
-        prescription.diagnosis = object.diagnosis || prescription.diagnosis
-        prescription.ttl = object.ttl || prescription.ttl
-        prescription.setInstitution(object.institution)
-        prescription.setAffiliate(object.affiliate)
-        prescription.setDoctor(object.doctor)
-        prescription.setMedicalInsurance(object.medicalInsurance)
-        prescription.status = object.status || prescription.status
-        prescription.norm = object.norm || prescription.norm
-        if (object.items && object.items.length){
-            object.items.forEach(item => prescription.addItem(item))
-        }
-        return prescription
+  static fromJson(json = '{}') {
+    if (!json) {
+      return new Prescription()
     }
+    const object = typeof json === 'object' ? json : JSON.parse(json)
+    const prescription = new Prescription()
+    prescription.id = object.id || prescription.id
+    prescription.setIssuedDate(object.issuedDate)
+    prescription.setSoldDate(object.soldDate)
+    prescription.setAuditedDate(object.auditedDate)
+    prescription.prolongedTreatment = object.prolongedTreatment
+    prescription.diagnosis = object.diagnosis || prescription.diagnosis
+    prescription.ttl = object.ttl || prescription.ttl
+    prescription.setInstitution(object.institution)
+    prescription.setAffiliate(object.affiliate)
+    prescription.setDoctor(object.doctor)
+    prescription.setMedicalInsurance(object.medicalInsurance)
+    prescription.status = object.status || prescription.status
+    prescription.norm = object.norm || prescription.norm
+    if (object.items && object.items.length) {
+      object.items.forEach(item => prescription.addItem(item))
+    }
+    return prescription
+  }
 
-    static fromObject(object){
-        if (!(object instanceof Prescription)){
-            return Prescription.fromJson(object)
-        }
-        return object 
+  static fromObject(object) {
+    if (!(object instanceof Prescription)) {
+      return Prescription.fromJson(object)
     }
+    return object
+  }
 
-    clone(){
-        return Prescription.fromJson(this.toJson())
-    }
+  clone() {
+    return Prescription.fromJson(this.toJson())
+  }
 }
 
-module.exports = {Prescription}
+module.exports = { Prescription }

--- a/src/init/init.js
+++ b/src/init/init.js
@@ -1,4 +1,4 @@
-//TODO: manejar el asincronismo
+// TODO: manejar el asincronismo
 const initDatabase = require('./initDatabase').init
 const initServer = require('./initServer').init
 

--- a/src/init/initDatabase.js
+++ b/src/init/initDatabase.js
@@ -1,7 +1,7 @@
-const {generateData} = require('../bootstrap/bootstrap')
+const { generateData } = require('../bootstrap/bootstrap')
 
 const init = async () => {
-    await generateData()
+  await generateData()
 }
 
-module.exports = {init}
+module.exports = { init }

--- a/src/init/initServer.js
+++ b/src/init/initServer.js
@@ -1,10 +1,11 @@
 const { logger } = require('../utils/utils')
+
 const init = () => {
   const express = require('express')
   const bodyParser = require('body-parser')
   const app = express()
   const port = 8080
-  
+
   app.locals.logger = logger
 
   app.use('/', require('../routes/index.js'))

--- a/src/middlewares/error-handler.js
+++ b/src/middlewares/error-handler.js
@@ -1,15 +1,15 @@
-const {isBusinessError} = require('../utils/errors')
+const { isBusinessError } = require('../utils/errors')
 
 const errorHandler = (err, req, res, next) => {
-    const {logger} = req.app.locals
-    if (res.headersSent) {
-        return next(err)
-    }
-    if (isBusinessError(err)){
-        return res.status(err.status).json(err)
-    }
-    logger.error(err.stack)
-    return res.status(500).json(err)
+  const { logger } = req.app.locals
+  if (res.headersSent) {
+    return next(err)
+  }
+  if (isBusinessError(err)) {
+    return res.status(err.status).json(err)
+  }
+  logger.error(err.stack)
+  return res.status(500).json(err)
 }
 
 module.exports = errorHandler

--- a/src/middlewares/logger.js
+++ b/src/middlewares/logger.js
@@ -1,7 +1,7 @@
 const loggerMiddleware = (req, res, next) => {
-    const {logger} = req.app.locals
-    logger.info(`${req.method} to ${req.originalUrl} ${req.method === 'POST' ? 'with payload: ' + JSON.stringify(req.body) : ''}`)
-    return next()
+  const { logger } = req.app.locals
+  logger.info(`${req.method} to ${req.originalUrl} ${req.method === 'POST' ? `with payload: ${JSON.stringify(req.body)}` : ''}`)
+  return next()
 }
 
 module.exports = loggerMiddleware

--- a/src/permissions/identifiedUser.js
+++ b/src/permissions/identifiedUser.js
@@ -1,130 +1,122 @@
-const filters = require('../filters/prescriptions/prescriptionFilters')
 const lang = require('lodash/lang')
-const {newForbiddenResourceException} = require('../utils/errors')
+const filters = require('../filters/prescriptions/prescriptionFilters')
+const { newForbiddenResourceException } = require('../utils/errors')
 
 const userTypes = {
-    AFFILIATE: "affiliate",
-    DOCTOR: "doctor",
-    PHARMACIST: "pharmacist",
-    MEDICAL_INSURANCE: "medicalInsurance"
+  AFFILIATE: 'affiliate',
+  DOCTOR: 'doctor',
+  PHARMACIST: 'pharmacist',
+  MEDICAL_INSURANCE: 'medicalInsurance',
 }
 
 const availableActions = {
-    CANCEL: "CANCEL",
-    RECEIVE: "RECEIVE",
-    AUDIT: "AUDIT"
+  CANCEL: 'CANCEL',
+  RECEIVE: 'RECEIVE',
+  AUDIT: 'AUDIT',
 }
 
 const identifiedUser = {
-    id: null,
-    type: null,
-    getFilters: null,
-    getQuery: null,
-    checkForbiden: null,
-    getActions: null
+  id: null,
+  type: null,
+  getFilters: null,
+  getQuery: null,
+  checkForbiden: null,
+  getActions: null,
 }
 
 const identifiedAffiliate = {
-    ...identifiedUser,
-    type: userTypes.AFFILIATE,
-    getFilters: filters.getAffiliateAvailableFilters,
-    getQuery: function(params) {
-        return filters.getAffiliateQueryByParams(params, this.id)
-    },
-    checkForbiden: function(prescription) {
-        if (prescription.affiliate.id !== this.id){
-            throw newForbiddenResourceException("Can't access this prescription")
-        }
-    },
-    getActions: (prescription) => {
-        return []
+  ...identifiedUser,
+  type: userTypes.AFFILIATE,
+  getFilters: filters.getAffiliateAvailableFilters,
+  getQuery(params) {
+    return filters.getAffiliateQueryByParams(params, this.id)
+  },
+  checkForbiden(prescription) {
+    if (prescription.affiliate.id !== this.id) {
+      throw newForbiddenResourceException("Can't access this prescription")
     }
+  },
+  getActions: prescription => [],
 }
 
 const identifiedDoctor = {
-    ...identifiedUser,
-    type: userTypes.DOCTOR,
-    getFilters: filters.getDoctorAvailableFilters,
-    getQuery: function(params) {
-        return filters.getDoctorQueryByParams(params, this.id)
-    },
-    checkForbiden: function(prescription){
-        if (prescription.doctor.id !== this.id){
-            throw newForbiddenResourceException("Can't access this prescription")
-        }
-    },
-    getActions: (prescription) => {
-        return [
-            availableActions.CANCEL
-        ]
+  ...identifiedUser,
+  type: userTypes.DOCTOR,
+  getFilters: filters.getDoctorAvailableFilters,
+  getQuery(params) {
+    return filters.getDoctorQueryByParams(params, this.id)
+  },
+  checkForbiden(prescription) {
+    if (prescription.doctor.id !== this.id) {
+      throw newForbiddenResourceException("Can't access this prescription")
     }
+  },
+  getActions: prescription => [
+    availableActions.CANCEL,
+  ],
 }
 
 const identifiedPharmacist = {
-    ...identifiedUser,
-    type: userTypes.PHARMACIST,
-    getFilters: filters.getPharmacistAvailableFilters,
-    getQuery: function(params) {
-        return filters.getPharmacistQueryByParams(params, this.id)
-    },
-    checkForbiden: function(prescription){
-        if (prescription.items.every(item => item.received.pharmacist.id !== this.id)){
-            throw newForbiddenResourceException("Can't access this prescription")
-        }
-    },
-    getActions: (prescription) => {
-        return [
-            availableActions.RECEIVE
-        ]
+  ...identifiedUser,
+  type: userTypes.PHARMACIST,
+  getFilters: filters.getPharmacistAvailableFilters,
+  getQuery(params) {
+    return filters.getPharmacistQueryByParams(params, this.id)
+  },
+  checkForbiden(prescription) {
+    if (prescription.items.every(item => item.received.pharmacist.id !== this.id)) {
+      throw newForbiddenResourceException("Can't access this prescription")
     }
+  },
+  getActions: prescription => [
+    availableActions.RECEIVE,
+  ],
 }
 
 const identifiedMedicalInsurance = {
-    ...identifiedUser,
-    type: userTypes.MEDICAL_INSURANCE,
-    getFilters: filters.getMedicalInsuranceAvailableFilters,
-    getQuery: function(params) {
-        return filters.getMedicalInsuranceQueryByParams(params, this.id)
-    },
-    checkForbiden: function(prescription){
-        if (prescription.medicalInsurance.id !== this.id){
-            throw newForbiddenResourceException("Can't access this prescription")
-        }
-    },
-    getActions: (prescription) => {
-        return [
-            availableActions.AUDIT
-        ]
+  ...identifiedUser,
+  type: userTypes.MEDICAL_INSURANCE,
+  getFilters: filters.getMedicalInsuranceAvailableFilters,
+  getQuery(params) {
+    return filters.getMedicalInsuranceQueryByParams(params, this.id)
+  },
+  checkForbiden(prescription) {
+    if (prescription.medicalInsurance.id !== this.id) {
+      throw newForbiddenResourceException("Can't access this prescription")
     }
+  },
+  getActions: prescription => [
+    availableActions.AUDIT,
+  ],
 }
 
 const getIdentifiedAffiliate = (id) => {
-    const affiliate = lang.cloneDeep(identifiedAffiliate)
-    affiliate.id = id
-    return affiliate
+  const affiliate = lang.cloneDeep(identifiedAffiliate)
+  affiliate.id = id
+  return affiliate
 }
 
 const getIdentifiedDoctor = (id) => {
-    const doctor = lang.cloneDeep(identifiedDoctor)
-    doctor.id = id
-    return doctor
+  const doctor = lang.cloneDeep(identifiedDoctor)
+  doctor.id = id
+  return doctor
 }
 
 const getIdentifiedPharmacist = (id) => {
-    const pharmacist = lang.cloneDeep(identifiedPharmacist)
-    pharmacist.id = id
-    return pharmacist
+  const pharmacist = lang.cloneDeep(identifiedPharmacist)
+  pharmacist.id = id
+  return pharmacist
 }
 
 const getIdentifiedMedicalInsurance = (id) => {
-    const medicalInsurance = lang.cloneDeep(identifiedMedicalInsurance)
-    medicalInsurance.id = id
-    return medicalInsurance
+  const medicalInsurance = lang.cloneDeep(identifiedMedicalInsurance)
+  medicalInsurance.id = id
+  return medicalInsurance
 }
 
 module.exports = {
-    getIdentifiedAffiliate,
-    getIdentifiedDoctor,
-    getIdentifiedPharmacist,
-    getIdentifiedMedicalInsurance
+  getIdentifiedAffiliate,
+  getIdentifiedDoctor,
+  getIdentifiedPharmacist,
+  getIdentifiedMedicalInsurance,
 }

--- a/src/repositories/affiliateRepository.js
+++ b/src/repositories/affiliateRepository.js
@@ -1,51 +1,45 @@
-const {Affiliate} = require('../domain/affiliate')
-const {newNotFoundError, newEntityAlreadyCreated} = require('../utils/errors')
-const {generateNewSequencer} = require('../utils/utils')
+const { Affiliate } = require('../domain/affiliate')
+const { newNotFoundError, newEntityAlreadyCreated } = require('../utils/errors')
+const { generateNewSequencer } = require('../utils/utils')
 
 const sequencer = generateNewSequencer()
 
 class AffiliateRepository {
-    constructor() {
-        this.affiliates = []
-    }
+  constructor() {
+    this.affiliates = []
+  }
 
-    create(_affiliate){
-        return new Promise((resolve, reject) => {
-            const affiliate = Affiliate.fromObject(_affiliate)
-            if (affiliate.id) {
-              return reject(newEntityAlreadyCreated('Affiliate allready created'))
-            }
-            affiliate.id = sequencer.nextValue()
-            this.affiliates.push(affiliate)
-            return resolve(affiliate)
-        })
-    }
+  create(_affiliate) {
+    return new Promise((resolve, reject) => {
+      const affiliate = Affiliate.fromObject(_affiliate)
+      if (affiliate.id) {
+        return reject(newEntityAlreadyCreated('Affiliate allready created'))
+      }
+      affiliate.id = sequencer.nextValue()
+      this.affiliates.push(affiliate)
+      return resolve(affiliate)
+    })
+  }
 
-    getAll() {
-        return new Promise((resolve, reject) => {
-            return resolve([...this.affiliates])
-        })
-    }
+  getAll() {
+    return new Promise((resolve, reject) => resolve([...this.affiliates]))
+  }
 
-    getByQuery(query) {
-        return new Promise((resolve, reject) => {
-            return resolve(this.affiliates.filter(affiliate => affiliate.code.includes(query.credential || '')))
-        })
-    }
+  getByQuery(query) {
+    return new Promise((resolve, reject) => resolve(this.affiliates.filter(affiliate => affiliate.code.includes(query.credential || ''))))
+  }
 
-    getById(id){
-        id = +id
-        return new Promise((resolve, reject) => {
-            const affiliate = this.affiliates.find((affiliate) => {
-                return affiliate.id === id
-            })
-            if (affiliate){
-                return resolve(Affiliate.fromObject(affiliate))
-            }
-            return reject(newNotFoundError(`No affiliate was found with id ${id}`))
-        })
-    }
+  getById(id) {
+    id = +id
+    return new Promise((resolve, reject) => {
+      const affiliate = this.affiliates.find(affiliate => affiliate.id === id)
+      if (affiliate) {
+        return resolve(Affiliate.fromObject(affiliate))
+      }
+      return reject(newNotFoundError(`No affiliate was found with id ${id}`))
+    })
+  }
 }
 module.exports = {
-    AffiliateRepository: new AffiliateRepository()
+  AffiliateRepository: new AffiliateRepository(),
 }

--- a/src/repositories/doctorRepository.js
+++ b/src/repositories/doctorRepository.js
@@ -1,45 +1,41 @@
-const {Doctor} = require('../domain/doctor')
-const {newNotFoundError, newEntityAlreadyCreated} = require('../utils/errors')
-const {generateNewSequencer} = require('../utils/utils')
+const { Doctor } = require('../domain/doctor')
+const { newNotFoundError, newEntityAlreadyCreated } = require('../utils/errors')
+const { generateNewSequencer } = require('../utils/utils')
 
 const sequencer = generateNewSequencer()
 
 class DoctorRepository {
-    constructor() {
-        this.doctors = []
-    }
+  constructor() {
+    this.doctors = []
+  }
 
-    create(_doctor){
-        return new Promise((resolve, reject) => {
-            const doctor = Doctor.fromObject(_doctor)
-            if (doctor.id) {
-              return reject(newEntityAlreadyCreated('Doctor allready created'))
-            }
-            doctor.id = sequencer.nextValue()
-            this.doctors.push(doctor)
-            return resolve(doctor)
-        })
-    }
+  create(_doctor) {
+    return new Promise((resolve, reject) => {
+      const doctor = Doctor.fromObject(_doctor)
+      if (doctor.id) {
+        return reject(newEntityAlreadyCreated('Doctor allready created'))
+      }
+      doctor.id = sequencer.nextValue()
+      this.doctors.push(doctor)
+      return resolve(doctor)
+    })
+  }
 
-    getAll() {
-        return new Promise((resolve, reject) => {
-            return resolve([...this.doctors])
-        })
-    }
+  getAll() {
+    return new Promise((resolve, reject) => resolve([...this.doctors]))
+  }
 
-    getById(id) {
-        id = +id
-        return new Promise((resolve, reject) => {
-            const doctor = this.doctors.find((doctor) => {
-                return doctor.id === id
-            })
-            if (doctor) {
-                return resolve(Doctor.fromObject(doctor))
-            }
-            return reject(newNotFoundError(`No doctor was found with id ${id}`))
-        })
-    }
+  getById(id) {
+    id = +id
+    return new Promise((resolve, reject) => {
+      const doctor = this.doctors.find(doctor => doctor.id === id)
+      if (doctor) {
+        return resolve(Doctor.fromObject(doctor))
+      }
+      return reject(newNotFoundError(`No doctor was found with id ${id}`))
+    })
+  }
 }
 module.exports = {
-    DoctorRepository: new DoctorRepository()
+  DoctorRepository: new DoctorRepository(),
 }

--- a/src/repositories/institutionRepository.js
+++ b/src/repositories/institutionRepository.js
@@ -1,46 +1,42 @@
 const { Institution } = require('../domain/institution')
 const { newNotFoundError, newEntityAlreadyCreated } = require('../utils/errors')
-const {generateNewSequencer} = require('../utils/utils')
+const { generateNewSequencer } = require('../utils/utils')
 
 const sequencer = generateNewSequencer()
 
 class InstitutionRepository {
-    constructor() {
-        this.institutions = []
-    }
+  constructor() {
+    this.institutions = []
+  }
 
-    create(_institution) {
-        return new Promise((resolve, reject) => {
-            const institution = Institution.fromObject(_institution)
-            if (institution.id) {
-                return reject(newEntityAlreadyCreated('Institution allready created'))
-            }
-            institution.id = sequencer.nextValue()
-            this.institutions.push(institution)
-            return resolve(institution)
-        })
-    }
+  create(_institution) {
+    return new Promise((resolve, reject) => {
+      const institution = Institution.fromObject(_institution)
+      if (institution.id) {
+        return reject(newEntityAlreadyCreated('Institution allready created'))
+      }
+      institution.id = sequencer.nextValue()
+      this.institutions.push(institution)
+      return resolve(institution)
+    })
+  }
 
-    getAll() {
-        return new Promise((resolve, reject) => {
-            return resolve([...this.institutions])
-        })
-    }
+  getAll() {
+    return new Promise((resolve, reject) => resolve([...this.institutions]))
+  }
 
-    getById(id) {
-        id = +id
-        return new Promise((resolve, reject) => {
-            const institution = this.institutions.find((institution) => {
-                return institution.id === id
-            })
-            if (institution) {
-                return resolve(Institution.fromObject(institution))
-            }
-            return reject(newNotFoundError(`No institution was found with id ${id}`))
-        })
-    }
+  getById(id) {
+    id = +id
+    return new Promise((resolve, reject) => {
+      const institution = this.institutions.find(institution => institution.id === id)
+      if (institution) {
+        return resolve(Institution.fromObject(institution))
+      }
+      return reject(newNotFoundError(`No institution was found with id ${id}`))
+    })
+  }
 }
 
 module.exports = {
-    InstitutionRepository: new InstitutionRepository()
+  InstitutionRepository: new InstitutionRepository(),
 }

--- a/src/repositories/medicalInsuranceRepository.js
+++ b/src/repositories/medicalInsuranceRepository.js
@@ -1,51 +1,46 @@
 const { MedicalInsurance } = require('../domain/medicalInsurance')
 const { newNotFoundError, newEntityAlreadyCreated } = require('../utils/errors')
-const {generateNewSequencer} = require('../utils/utils')
+const { generateNewSequencer } = require('../utils/utils')
 
 const sequencer = generateNewSequencer()
 
 class MedicalInsuranceRepository {
-    constructor() {
-        this.medicalInsurances = []
-    }
+  constructor() {
+    this.medicalInsurances = []
+  }
 
-    create(_medicalInsurance) {
-        return new Promise((resolve, reject) => {
-            const medicalInsurance = MedicalInsurance.fromObject(_medicalInsurance)
-            if (medicalInsurance.id) {
-                return reject(newEntityAlreadyCreated('Medical Insurance allready created'))
-            }
-            medicalInsurance.id = sequencer.nextValue()
-            this.medicalInsurances.push(medicalInsurance)
-            return resolve(medicalInsurance)
-        })
-    }
+  create(_medicalInsurance) {
+    return new Promise((resolve, reject) => {
+      const medicalInsurance = MedicalInsurance.fromObject(_medicalInsurance)
+      if (medicalInsurance.id) {
+        return reject(newEntityAlreadyCreated('Medical Insurance allready created'))
+      }
+      medicalInsurance.id = sequencer.nextValue()
+      this.medicalInsurances.push(medicalInsurance)
+      return resolve(medicalInsurance)
+    })
+  }
 
-    getAll() {
-        return new Promise((resolve, reject) => {
-            return resolve([...this.medicalInsurances])
-        })
-    }
-    getMedicalInsuranceByMedic(doctorId) {
-        return new Promise((resolve, reject) => {
-            return resolve([...this.medicalInsurances])
-        })
-    }
+  getAll() {
+    return new Promise((resolve, reject) => resolve([...this.medicalInsurances]))
+  }
 
-    getById(id) {
-        id = +id
-        return new Promise((resolve, reject) => {
-            const medicalInsurance = this.medicalInsurances.find((medicalInsurance) => {
-                return medicalInsurance.id === id
-            })
-            if (medicalInsurance) {
-                return resolve(MedicalInsurance.fromObject(medicalInsurance))
-            }
-            return reject(newNotFoundError(`No medicalInsurance was found with id ${id}`))
-        })
-    }
+  getMedicalInsuranceByMedic(doctorId) {
+    return new Promise((resolve, reject) => resolve([...this.medicalInsurances]))
+  }
+
+  getById(id) {
+    id = +id
+    return new Promise((resolve, reject) => {
+      const medicalInsurance = this.medicalInsurances.find(medicalInsurance => medicalInsurance.id === id)
+      if (medicalInsurance) {
+        return resolve(MedicalInsurance.fromObject(medicalInsurance))
+      }
+      return reject(newNotFoundError(`No medicalInsurance was found with id ${id}`))
+    })
+  }
 }
 
 module.exports = {
-    MedicalInsuranceRepository: new MedicalInsuranceRepository()
+  MedicalInsuranceRepository: new MedicalInsuranceRepository(),
 }

--- a/src/repositories/medicineRepository.js
+++ b/src/repositories/medicineRepository.js
@@ -1,52 +1,46 @@
-const {Medicine} = require('../domain/medicine')
-const {newNotFoundError, newEntityAlreadyCreated} = require('../utils/errors')
-const {generateNewSequencer} = require('../utils/utils')
+const { Medicine } = require('../domain/medicine')
+const { newNotFoundError, newEntityAlreadyCreated } = require('../utils/errors')
+const { generateNewSequencer } = require('../utils/utils')
 
 const sequencer = generateNewSequencer()
 
 class MedicineRepository {
-    constructor() {
-        this.medicines = []
-    }
+  constructor() {
+    this.medicines = []
+  }
 
-    create(_medicine){
-        return new Promise((resolve, reject) => {
-            const medicine = Medicine.fromObject(_medicine)
-            if (medicine.id) {
-              return reject(newEntityAlreadyCreated('Medicine allready created'))
-            }
-            medicine.id = sequencer.nextValue()
-            this.medicines.push(medicine)
-            return resolve(medicine)
-        })
-    }
+  create(_medicine) {
+    return new Promise((resolve, reject) => {
+      const medicine = Medicine.fromObject(_medicine)
+      if (medicine.id) {
+        return reject(newEntityAlreadyCreated('Medicine allready created'))
+      }
+      medicine.id = sequencer.nextValue()
+      this.medicines.push(medicine)
+      return resolve(medicine)
+    })
+  }
 
-    getAll() {
-        return new Promise((resolve, reject) => {
-            return resolve([...this.medicines])
-        })
-    }
+  getAll() {
+    return new Promise((resolve, reject) => resolve([...this.medicines]))
+  }
 
-    getByQuery(query) {
-        return new Promise((resolve, reject) => {
-            return resolve(this.medicines.filter(medicine => medicine.description.includes(query.description || '')))
-        })
-    }
+  getByQuery(query) {
+    return new Promise((resolve, reject) => resolve(this.medicines.filter(medicine => medicine.description.includes(query.description || ''))))
+  }
 
-    getById(id){
-        id = +id
-        return new Promise((resolve, reject) => {
-            const medicine = this.medicines.find((medicine) => {
-                return medicine.id === id
-            })
-            if (medicine){
-                return resolve(Medicine.fromObject(medicine))
-            }
-            return reject(newNotFoundError(`No medicine was found with id ${id}`))
-        })
-    }
+  getById(id) {
+    id = +id
+    return new Promise((resolve, reject) => {
+      const medicine = this.medicines.find(medicine => medicine.id === id)
+      if (medicine) {
+        return resolve(Medicine.fromObject(medicine))
+      }
+      return reject(newNotFoundError(`No medicine was found with id ${id}`))
+    })
+  }
 }
 
 module.exports = {
-    MedicineRepository : new MedicineRepository()
+  MedicineRepository: new MedicineRepository(),
 }

--- a/src/repositories/pharmacistRepository.js
+++ b/src/repositories/pharmacistRepository.js
@@ -1,45 +1,41 @@
-const {Pharmacist} = require('../domain/pharmacist')
-const {newNotFoundError, newEntityAlreadyCreated} = require('../utils/errors')
-const {generateNewSequencer} = require('../utils/utils')
+const { Pharmacist } = require('../domain/pharmacist')
+const { newNotFoundError, newEntityAlreadyCreated } = require('../utils/errors')
+const { generateNewSequencer } = require('../utils/utils')
 
 const sequencer = generateNewSequencer()
 
 class PharmacistRepository {
-    constructor() {
-        this.pharmacists = []
-    }
+  constructor() {
+    this.pharmacists = []
+  }
 
-    create(_pharmacist){
-        return new Promise((resolve, reject) => {
-            const pharmacist = Pharmacist.fromObject(_pharmacist)
-            if (pharmacist.id) {
-              return reject(newEntityAlreadyCreated('Pharmacist allready created'))
-            }
-            pharmacist.id = sequencer.nextValue()
-            this.pharmacists.push(pharmacist)
-            return resolve(pharmacist)
-        })
-    }
+  create(_pharmacist) {
+    return new Promise((resolve, reject) => {
+      const pharmacist = Pharmacist.fromObject(_pharmacist)
+      if (pharmacist.id) {
+        return reject(newEntityAlreadyCreated('Pharmacist allready created'))
+      }
+      pharmacist.id = sequencer.nextValue()
+      this.pharmacists.push(pharmacist)
+      return resolve(pharmacist)
+    })
+  }
 
-    getAll() {
-        return new Promise((resolve, reject) => {
-            return resolve([...this.pharmacists])
-        })
-    }
+  getAll() {
+    return new Promise((resolve, reject) => resolve([...this.pharmacists]))
+  }
 
-    getById(id) {
-        id = +id
-        return new Promise((resolve, reject) => {
-            const pharmacist = this.pharmacists.find((pharmacist) => {
-                return pharmacist.id === id
-            })
-            if (pharmacist) {
-                return resolve(Pharmacist.fromObject(pharmacist))
-            }
-            return reject(newNotFoundError(`No pharmacist was found with id ${id}`))
-        })
-    }
+  getById(id) {
+    id = +id
+    return new Promise((resolve, reject) => {
+      const pharmacist = this.pharmacists.find(pharmacist => pharmacist.id === id)
+      if (pharmacist) {
+        return resolve(Pharmacist.fromObject(pharmacist))
+      }
+      return reject(newNotFoundError(`No pharmacist was found with id ${id}`))
+    })
+  }
 }
 module.exports = {
-    PharmacistRepository: new PharmacistRepository()
+  PharmacistRepository: new PharmacistRepository(),
 }

--- a/src/repositories/prescriptions-repository.js
+++ b/src/repositories/prescriptions-repository.js
@@ -1,139 +1,147 @@
-const {Prescription} = require('../domain/prescription')
-const {newNotFoundError, newEntityAlreadyCreated} = require('../utils/errors')
-const {AffiliateRepository} = require('../repositories/affiliateRepository')
-const {InstitutionRepository} = require('../repositories/institutionRepository')
-const {MedicalInsuranceRepository} = require('../repositories/medicalInsuranceRepository')
-const {MedicineRepository} = require('../repositories/medicineRepository')
-const {DoctorRepository} = require('../repositories/doctorRepository')
-const {PharmacistRepository} = require('../repositories/pharmacistRepository')
-const {generateNewSequencer} = require('../utils/utils')
+const { Prescription } = require('../domain/prescription')
+const { newNotFoundError, newEntityAlreadyCreated } = require('../utils/errors')
+const { AffiliateRepository } = require('../repositories/affiliateRepository')
+const { InstitutionRepository } = require('../repositories/institutionRepository')
+const { MedicalInsuranceRepository } = require('../repositories/medicalInsuranceRepository')
+const { MedicineRepository } = require('../repositories/medicineRepository')
+const { DoctorRepository } = require('../repositories/doctorRepository')
+const { PharmacistRepository } = require('../repositories/pharmacistRepository')
+const { generateNewSequencer } = require('../utils/utils')
 
 const sequencer = generateNewSequencer()
 
 class PrescriptionRepository {
-    constructor(){
-        this.prescriptions = []
-    }
+  constructor() {
+    this.prescriptions = []
+  }
 
-    reset(){
-        return new Promise((resolve, reject) => {
-            this.prescriptions = []
-            return resolve()
-        })
-    }
+  reset() {
+    return new Promise((resolve, reject) => {
+      this.prescriptions = []
+      return resolve()
+    })
+  }
 
-    create(_prescription){
-        return new Promise(async (resolve, reject) => {
-            const prescription = Prescription.fromObject(_prescription).clone()
-            if (prescription.id){
-                return reject(newEntityAlreadyCreated('Prescription allready created'))
-            }
-            const errors = []
-            try {
-                prescription.setAffiliate(prescription.affiliate.id && await AffiliateRepository.getById(prescription.affiliate.id) || prescription.affiliate)
-            } catch (error){errors.push(error)}
-            try {
-                prescription.setInstitution(prescription.institution.id && await InstitutionRepository.getById(prescription.institution.id || prescription.institution))
-            } catch (error){errors.push(error)}
-            try {
-                prescription.setMedicalInsurance(prescription.medicalInsurance.id && await MedicalInsuranceRepository.getById(prescription.medicalInsurance.id || prescription.medicalInsurance))
-            } catch (error){errors.push(error)}
-            try {
-                prescription.setDoctor(prescription.doctor.id && await DoctorRepository.getById(prescription.doctor.id || prescription.doctor))
-            } catch (error){errors.push(error)}
-            for(const item of prescription.items){
-                try {
-                    item.prescribed.medicine = item.prescribed.medicine.id && await MedicineRepository.getById(item.prescribed.medicine.id) || item.prescribed.medicine
-                } catch (error){errors.push(error)}
-                try {
-                    item.received.medicine = item.received.medicine.id && await MedicineRepository.getById(item.received.medicine.id) || item.received.medicine
-                } catch (error){errors.push(error)}
-                try {
-                    item.received.pharmacist = item.received.pharmacist.id && await PharmacistRepository.getById(item.received.pharmacist.id) || item.received.pharmacist
-                } catch (error){errors.push(error)}
-                try {
-                    item.audited.medicine = item.audited.medicine.id && await MedicineRepository.getById(item.audited.medicine.id) || item.audited.medicine
-                } catch (error){errors.push(error)}
-            }
-            if (errors.length){
-                return reject(errors)
-            }
-            prescription.id = sequencer.nextValue()
-            this.prescriptions.push(prescription)
-            return resolve(prescription)
-        })
-    }
+  create(_prescription) {
+    return new Promise(async (resolve, reject) => {
+      const prescription = Prescription.fromObject(_prescription).clone()
+      if (prescription.id) {
+        return reject(newEntityAlreadyCreated('Prescription allready created'))
+      }
+      const errors = []
+      try {
+        prescription.setAffiliate((prescription.affiliate.id && (await AffiliateRepository.getById(prescription.affiliate.id))) || prescription.affiliate)
+      } catch (error) {
+        errors.push(error)
+      }
+      try {
+        prescription.setInstitution(
+          prescription.institution.id && (await InstitutionRepository.getById(prescription.institution.id || prescription.institution)),
+        )
+      } catch (error) {
+        errors.push(error)
+      }
+      try {
+        prescription.setMedicalInsurance(
+          prescription.medicalInsurance.id && (await MedicalInsuranceRepository.getById(prescription.medicalInsurance.id || prescription.medicalInsurance)),
+        )
+      } catch (error) {
+        errors.push(error)
+      }
+      try {
+        prescription.setDoctor(prescription.doctor.id && (await DoctorRepository.getById(prescription.doctor.id || prescription.doctor)))
+      } catch (error) {
+        errors.push(error)
+      }
+      for (const item of prescription.items) {
+        try {
+          item.prescribed.medicine = (item.prescribed.medicine.id && (await MedicineRepository.getById(item.prescribed.medicine.id))) || item.prescribed.medicine
+        } catch (error) {
+          errors.push(error)
+        }
+        try {
+          item.received.medicine = (item.received.medicine.id && (await MedicineRepository.getById(item.received.medicine.id))) || item.received.medicine
+        } catch (error) {
+          errors.push(error)
+        }
+        try {
+          item.received.pharmacist = (item.received.pharmacist.id && (await PharmacistRepository.getById(item.received.pharmacist.id))) || item.received.pharmacist
+        } catch (error) {
+          errors.push(error)
+        }
+        try {
+          item.audited.medicine = (item.audited.medicine.id && (await MedicineRepository.getById(item.audited.medicine.id))) || item.audited.medicine
+        } catch (error) {
+          errors.push(error)
+        }
+      }
+      if (errors.length) {
+        return reject(errors)
+      }
+      prescription.id = sequencer.nextValue()
+      this.prescriptions.push(prescription)
+      return resolve(prescription)
+    })
+  }
 
-    update(_prescription){
-        return new Promise((resolve, reject) => {
-            const prescription = Prescription.fromObject(_prescription)
-            if (!prescription.id || !this.prescriptions.some((pres) => {return prescription.id === pres.id})){
-                return reject(newNotFoundError('Prescription not found'))
-            }
-            this.prescriptions = this.prescriptions.filter((pres) => {
-                return pres.id !== prescription.id
-            })
-            const newPrescription = Prescription.fromJson(prescription.toJson())
-            this.prescriptions.push(newPrescription)
-            return resolve(newPrescription)
-        })
-    }
+  update(_prescription) {
+    return new Promise((resolve, reject) => {
+      const prescription = Prescription.fromObject(_prescription)
+      if (!prescription.id || !this.prescriptions.some(pres => prescription.id === pres.id)) {
+        return reject(newNotFoundError('Prescription not found'))
+      }
+      this.prescriptions = this.prescriptions.filter(pres => pres.id !== prescription.id)
+      const newPrescription = Prescription.fromJson(prescription.toJson())
+      this.prescriptions.push(newPrescription)
+      return resolve(newPrescription)
+    })
+  }
 
-    count(){
-        return new Promise((resolve, reject) => {
-            return resolve(this.prescriptions.length)
-        })
-    }
+  count() {
+    return new Promise((resolve, reject) => resolve(this.prescriptions.length))
+  }
 
-    getAll(){
-        return new Promise((resolve, reject) => {
-            return resolve([...this.prescriptions])
-        })
-    }
+  getAll() {
+    return new Promise((resolve, reject) => resolve([...this.prescriptions]))
+  }
 
-    getById(id){
-        id = +id
-        return new Promise((resolve, reject) => {
-            const prescription = this.prescriptions.find((prescription) => {
-                return prescription.id === id
-            })
-            if (prescription){
-                return resolve(Prescription.fromObject(prescription))
-            }
-            return reject(newNotFoundError(`No prescription was found with id ${id}`))
-        })
-    }
+  getById(id) {
+    id = +id
+    return new Promise((resolve, reject) => {
+      const prescription = this.prescriptions.find(prescription => prescription.id === id)
+      if (prescription) {
+        return resolve(Prescription.fromObject(prescription))
+      }
+      return reject(newNotFoundError(`No prescription was found with id ${id}`))
+    })
+  }
 
-    getByExample(_prescription){
-        return new Promise((resolve, reject) => {
-            const searchedPrescription = Prescription.fromObject(_prescription)
-            const prescriptions = this.prescriptions.filter((aPrescription) => {
-                return searchedPrescription.issueDate && searchedPrescription.issueDate === aPrescription.issueDate ||
-                    searchedPrescription.soldDate && searchedPrescription.soldDate === aPrescription.soldDate ||
-                    searchedPrescription.auditedDate && searchedPrescription.auditedDate === aPrescription.auditedDate ||
-                    searchedPrescription.institution && searchedPrescription.institution.id === aPrescription.institution.id ||
-                    searchedPrescription.affiliate && searchedPrescription.affiliate.id === aPrescription.affiliate.id ||
-                    searchedPrescription.doctor && searchedPrescription.doctor.id === aPrescription.doctor.id ||
-                    searchedPrescription.medicalInsurance && searchedPrescription.medicalInsurance.id === aPrescription.medicalInsurance.id
-            })
-            return resolve(prescriptions)
-        })
-    }
+  getByExample(_prescription) {
+    return new Promise((resolve, reject) => {
+      const searchedPrescription = Prescription.fromObject(_prescription)
+      const prescriptions = this.prescriptions.filter(
+        aPrescription => (searchedPrescription.issueDate && searchedPrescription.issueDate === aPrescription.issueDate)
+          || (searchedPrescription.soldDate && searchedPrescription.soldDate === aPrescription.soldDate)
+          || (searchedPrescription.auditedDate && searchedPrescription.auditedDate === aPrescription.auditedDate)
+          || (searchedPrescription.institution && searchedPrescription.institution.id === aPrescription.institution.id)
+          || (searchedPrescription.affiliate && searchedPrescription.affiliate.id === aPrescription.affiliate.id)
+          || (searchedPrescription.doctor && searchedPrescription.doctor.id === aPrescription.doctor.id)
+          || (searchedPrescription.medicalInsurance && searchedPrescription.medicalInsurance.id === aPrescription.medicalInsurance.id),
+      )
+      return resolve(prescriptions)
+    })
+  }
 
-    getByStatus(status){
-        return new Promise((resolve, reject) => {
-            const prescriptions = this.prescriptions.filter((prescription) => {
-                return prescription.status === status
-            })
-            return resolve(prescriptions)
-        })
-    }
+  getByStatus(status) {
+    return new Promise((resolve, reject) => {
+      const prescriptions = this.prescriptions.filter(prescription => prescription.status === status)
+      return resolve(prescriptions)
+    })
+  }
 
-    getByQuery(query){
-        return new Promise((resolve, reject) => {
-            return resolve([...this.prescriptions])
-        })
-    }
+  getByQuery(query) {
+    return new Promise((resolve, reject) => resolve([...this.prescriptions]))
+  }
 }
 
-module.exports = {PrescriptionRepository: new PrescriptionRepository()}
+module.exports = { PrescriptionRepository: new PrescriptionRepository() }

--- a/src/routes/affiliate.js
+++ b/src/routes/affiliate.js
@@ -1,15 +1,16 @@
 const express = require('express')
+
 const router = express.Router()
 const { AffiliateRepository } = require('../repositories/affiliateRepository')
 
 router.get('/', async (req, res, next) => {
-    const query = req.query
-    try {
-        const affiliates = await AffiliateRepository.getByQuery(query)
-        return res.status(200).send(affiliates.map(affiliate => affiliate.toPlainObject()))
-    } catch (error) {
-        return next(error)
-    }
+  const { query } = req
+  try {
+    const affiliates = await AffiliateRepository.getByQuery(query)
+    return res.status(200).send(affiliates.map(affiliate => affiliate.toPlainObject()))
+  } catch (error) {
+    return next(error)
+  }
 })
 
 module.exports = router

--- a/src/routes/doctors.js
+++ b/src/routes/doctors.js
@@ -1,4 +1,5 @@
 const express = require('express')
+
 const router = express.Router()
 const { MedicalInsuranceRepository } = require('../repositories/medicalInsuranceRepository')
 const { DoctorRepository } = require('../repositories/doctorRepository')
@@ -15,10 +16,8 @@ router.get('/:id/medical-insurances', async (req, res, next) => {
 
 router.get('/', (req, res, next) => {
   DoctorRepository.getAll()
-  .then(doctors => {
-    return res.json(doctors.map(doctor => doctor.toPlainObject()))
-  })
-  .catch(next)
+    .then(doctors => res.json(doctors.map(doctor => doctor.toPlainObject())))
+    .catch(next)
 })
 
 module.exports = router

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,4 +1,5 @@
 const express = require('express')
+
 const appRouter = express.Router()
 const bodyParser = require('body-parser')
 

--- a/src/routes/institution.js
+++ b/src/routes/institution.js
@@ -1,4 +1,5 @@
 const express = require('express')
+
 const router = express.Router()
 const { InstitutionRepository } = require('../repositories/institutionRepository')
 

--- a/src/routes/medicalInsurance.js
+++ b/src/routes/medicalInsurance.js
@@ -1,4 +1,5 @@
 const express = require('express')
+
 const router = express.Router()
 const { MedicalInsuranceRepository } = require('../repositories/medicalInsuranceRepository')
 

--- a/src/routes/medicine.js
+++ b/src/routes/medicine.js
@@ -1,14 +1,15 @@
 const express = require('express')
+
 const router = express.Router()
 const { MedicineRepository } = require('../repositories/medicineRepository')
 
 router.get('/', async (req, res, next) => {
-    const query = req.query
-    try {
-        const medicines = await MedicineRepository.getByQuery(query)
-        return res.status(200).send(medicines.map(medicine => medicine.toPlainObject()))
-    } catch (error) {
-        return next(error)
-    }
+  const { query } = req
+  try {
+    const medicines = await MedicineRepository.getByQuery(query)
+    return res.status(200).send(medicines.map(medicine => medicine.toPlainObject()))
+  } catch (error) {
+    return next(error)
+  }
 })
-module.exports = router 
+module.exports = router

--- a/src/routes/pharmacist.js
+++ b/src/routes/pharmacist.js
@@ -1,12 +1,9 @@
 const express = require('express')
+
 const router = express.Router()
 const { PharmacistRepository } = require('../repositories/pharmacistRepository')
 
-router.get('/', (req, res, next) => {
-    return PharmacistRepository.getAll()
-    .then(pharmacists => {
-        return res.json(pharmacists.map(pharmacist => pharmacist.toPlainObject()))
-    })
-    .catch(next)
-})
-module.exports = router 
+router.get('/', (req, res, next) => PharmacistRepository.getAll()
+  .then(pharmacists => res.json(pharmacists.map(pharmacist => pharmacist.toPlainObject())))
+  .catch(next))
+module.exports = router

--- a/src/routes/ping.js
+++ b/src/routes/ping.js
@@ -1,4 +1,5 @@
 const express = require('express')
+
 const router = express.Router()
 
 router.get('/', (req, res) => res.status(200).send({ message: 'pong' }))

--- a/src/routes/prescriptions.js
+++ b/src/routes/prescriptions.js
@@ -1,4 +1,5 @@
 const express = require('express')
+
 const router = express.Router()
 const { Prescription } = require('../domain/prescription')
 const { StateMachine } = require('../state-machine/state-machine')
@@ -10,10 +11,8 @@ router.post('/', (req, res, next) => {
   const { logger } = req.app.locals
   const prescription = Prescription.fromObject(req.body)
   return StateMachine.toIssued(prescription)
-    .then(createdPrescription => {
-      return res.status(201).json(createdPrescription.toPlainObject())
-    })
-    .catch(err => {
+    .then(createdPrescription => res.status(201).json(createdPrescription.toPlainObject()))
+    .catch((err) => {
       if (isBusinessError(err)) {
         return next(newBadRequestError('Invalid prescription payload', err, 400))
       }
@@ -31,9 +30,9 @@ router.get('/', secureMiddleware, (req, res, next) => {
   const { identifiedUser } = req
   console.log(req.query.status)
   const prescriptionQuery = identifiedUser.getQuery(req.query)
-  console.log("prescriptionQuery", prescriptionQuery)
+  console.log('prescriptionQuery', prescriptionQuery)
   return PrescriptionRepository.getByQuery(prescriptionQuery)
-    .then(prescriptions => {
+    .then((prescriptions) => {
       const filters = identifiedUser.getFilters()
       const response = { result: prescriptions.map(pres => pres.toPlainObject()), ...filters }
       return res.json(response)
@@ -45,7 +44,7 @@ router.get('/:id', secureMiddleware, (req, res, next) => {
   const { logger } = req.app.locals
   const { identifiedUser } = req
   return PrescriptionRepository.getById(req.params.id)
-    .then(prescription => {
+    .then((prescription) => {
       identifiedUser.checkForbiden(prescription)
       const actions = identifiedUser.getActions(prescription)
       return res.json({ result: prescription.toPlainObject(), actions })

--- a/src/routes/session.js
+++ b/src/routes/session.js
@@ -1,10 +1,10 @@
 const express = require('express')
 const bodyParser = require('body-parser')
+
 const router = express.Router()
 
-router.post('/', bodyParser.json(), (req, res) => {
-    //TODO: hacer el login
-    return res.json(req.body)
-})
+router.post('/', bodyParser.json(), (req, res) =>
+// TODO: hacer el login
+  res.json(req.body))
 
 module.exports = router

--- a/src/state-machine/state-machine.js
+++ b/src/state-machine/state-machine.js
@@ -1,102 +1,102 @@
-const {states} = require('./state')
-const {PrescriptionRepository} = require('../repositories/prescriptions-repository')
+const { states } = require('./state')
+const { PrescriptionRepository } = require('../repositories/prescriptions-repository')
 const moment = require('moment')
 
 class StateMachine {
-    constructor(){
+  constructor() {
 
-    }
+  }
 
-    toIssued(prescription){
-        prescription.setIssuedDate(moment())
-        prescription.ttl = 30 //TODO: reemplazar con el llamado a tiempo de vida posta segun OS
-        prescription.norm = 1 //TODO: reemplazar con el llamado a norma vigente segun OS
-        return this.validateToIssued(prescription)
-        .then(() => {
-            prescription.status = states.ISSUED.status
-            return PrescriptionRepository.create(prescription)
-        })
-    }
+  toIssued(prescription) {
+    prescription.setIssuedDate(moment())
+    prescription.ttl = 30 // TODO: reemplazar con el llamado a tiempo de vida posta segun OS
+    prescription.norm = 1 // TODO: reemplazar con el llamado a norma vigente segun OS
+    return this.validateToIssued(prescription)
+      .then(() => {
+        prescription.status = states.ISSUED.status
+        return PrescriptionRepository.create(prescription)
+      })
+  }
 
-    validateToIssued(prescription){
-        return new Promise((resolve, reject) => {
-            states.ISSUED.validate(prescription)
-            //TODO: Llamar al validador de reglas de negocio
-            return resolve()
-        })
-    }
+  validateToIssued(prescription) {
+    return new Promise((resolve, reject) => {
+      states.ISSUED.validate(prescription)
+      // TODO: Llamar al validador de reglas de negocio
+      return resolve()
+    })
+  }
 
-    toCancelled(prescription){
+  toCancelled(prescription) {
 
-    }
+  }
 
-    validateToCancelled(prescription){
+  validateToCancelled(prescription) {
 
-    }
+  }
 
-    toConfirmed(prescription){
+  toConfirmed(prescription) {
 
-    }
+  }
 
-    validateToConfirmed(prescription){
+  validateToConfirmed(prescription) {
 
-    }
+  }
 
-    toExpired(prescription){
+  toExpired(prescription) {
 
-    }
+  }
 
-    validateToExpired(prescription){
+  validateToExpired(prescription) {
 
-    }
+  }
 
-    toReceived(prescription){
+  toReceived(prescription) {
 
-    }
+  }
 
-    validateToReceived(prescription){
+  validateToReceived(prescription) {
 
-    }
+  }
 
-    toPartiallyReceived(prescription){
+  toPartiallyReceived(prescription) {
 
-    }
+  }
 
-    validateToPartiallyReceived(prescription){
+  validateToPartiallyReceived(prescription) {
 
-    }
-    
-    toIncomplete(prescription){
+  }
 
-    }
+  toIncomplete(prescription) {
 
-    validateToIncomplete(prescription){
+  }
 
-    }
+  validateToIncomplete(prescription) {
 
-    toAudited(prescription){
+  }
 
-    }
+  toAudited(prescription) {
 
-    validateToAudited(prescription){
+  }
 
-    }
+  validateToAudited(prescription) {
 
-    toRejected(prescription){
+  }
 
-    }
+  toRejected(prescription) {
 
-    validateToRejected(prescription){
+  }
 
-    }
+  validateToRejected(prescription) {
 
-    toPartiallyRejected(prescription){
+  }
 
-    }
+  toPartiallyRejected(prescription) {
 
-    validateToPartiallyRejected(prescription){
-        
-    }
+  }
+
+  validateToPartiallyRejected(prescription) {
+
+  }
 }
 
-module.exports = {StateMachine: new StateMachine()}
+module.exports = { StateMachine: new StateMachine() }

--- a/src/state-machine/state.js
+++ b/src/state-machine/state.js
@@ -1,235 +1,217 @@
-const {newNullOrEmptyError, generateFieldCause} = require('../utils/errors')
-const {getArrayNotEmptyError, getNotNullError, getDiferentValueError, getValueNotInListError, getBeNullError, getArrayDoesntMatchError, getObjectDoesntMatchError} = require('../utils/errors')
-const {codes} = require('../codes/entities-codes')
+const { newNullOrEmptyError, generateFieldCause } = require('../utils/errors')
+const {
+  getArrayNotEmptyError, getNotNullError, getDiferentValueError, getValueNotInListError, getBeNullError, getArrayDoesntMatchError, getObjectDoesntMatchError,
+} = require('../utils/errors')
+const { codes } = require('../codes/entities-codes')
 const array = require('lodash/array')
 
-const {name: prescriptionEntity, fields: prescriptionFields} = codes.PRESCRIPTION
-const {name: affiliateEntity, fields: affiliateFields} = codes.AFFILIATE
-const {name: doctorEntity, fields: doctorFields} = codes.DOCTOR
-const {name: medicalInsuranceEntity, fields: medicalInsuranceFields} = codes.MEDICAL_INSURANCE
-const {name: itemEntity, fields: itemFields} = codes.ITEM
+const { name: prescriptionEntity, fields: prescriptionFields } = codes.PRESCRIPTION
+const { name: affiliateEntity, fields: affiliateFields } = codes.AFFILIATE
+const { name: doctorEntity, fields: doctorFields } = codes.DOCTOR
+const { name: medicalInsuranceEntity, fields: medicalInsuranceFields } = codes.MEDICAL_INSURANCE
+const { name: itemEntity, fields: itemFields } = codes.ITEM
 
-const validator = function(prescription){
-    if (!prescription){
-        throw [newNullOrEmptyError('prescription cant be null or empty', generateFieldCause(prescriptionEntity, null))]
-    }
-    const statusError = this.getStatusError(prescription)
-    const errors = array.compact(this.getErrors(prescription).concat(this.getSpecificErrors(prescription)))
-    if (statusError){
-        errors.push(statusError)
-    }
-    if (errors.length){
-        throw errors
-    }
+const validator = function (prescription) {
+  if (!prescription) {
+    throw [newNullOrEmptyError('prescription cant be null or empty', generateFieldCause(prescriptionEntity, null))]
+  }
+  const statusError = this.getStatusError(prescription)
+  const errors = array.compact(this.getErrors(prescription).concat(this.getSpecificErrors(prescription)))
+  if (statusError) {
+    errors.push(statusError)
+  }
+  if (errors.length) {
+    throw errors
+  }
 }
 const ISSUED = {
-    status: 'EMITIDA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getBeNullError(prescription.status, prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        const errors = [
-            getNotNullError(prescription.issuedDate, prescriptionEntity, prescriptionFields.issuedDate),
-            getNotNullError(prescription.ttl, prescriptionEntity, prescriptionFields.ttl),
-            getNotNullError(prescription.affiliate, prescriptionEntity, prescriptionFields.affiliate),
-            getObjectDoesntMatchError(prescription, 'affiliate.id', (value) => {return typeof value === 'number' && !!value}, affiliateEntity, affiliateFields.id),
-            getNotNullError(prescription.doctor, prescriptionEntity, prescriptionFields.doctor),
-            getObjectDoesntMatchError(prescription, 'doctor.id', (value) => {return typeof value === 'number' && !!value}, doctorEntity, doctorFields.id),
-            getNotNullError(prescription.medicalInsurance, prescriptionEntity, prescriptionFields.medicalInsurance),
-            getObjectDoesntMatchError(prescription, 'medicalInsurance.id', (value) => {return typeof value === 'number' && !!value}, medicalInsuranceEntity, medicalInsuranceFields.id),
-            getNotNullError(prescription.norm, prescriptionEntity, prescriptionFields.norm),
-            getArrayNotEmptyError(prescription.items, prescriptionEntity, prescriptionFields.items),
-            ...getArrayDoesntMatchError(prescription.items, 'prescribed.quantity', (value) => {return typeof value === 'number' && !!value}, itemEntity, itemFields.prescribed.quantity),
-            ...getArrayDoesntMatchError(prescription.items, 'prescribed.medicine.id', (value) => {return typeof value === 'number' && !!value}, itemEntity, itemFields.prescribed.medicine.id)
-        ]
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = [
-            getDiferentValueError(prescription.soldDate, null, prescriptionEntity, prescriptionFields.soldDate),
-            getDiferentValueError(prescription.auditedDate, null, prescriptionEntity, prescriptionFields.auditedDate)
-        ]
-        return errors
-    }
+  status: 'EMITIDA',
+  validate: validator,
+  getStatusError: prescription => getBeNullError(prescription.status, prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    const errors = [
+      getNotNullError(prescription.issuedDate, prescriptionEntity, prescriptionFields.issuedDate),
+      getNotNullError(prescription.ttl, prescriptionEntity, prescriptionFields.ttl),
+      getNotNullError(prescription.affiliate, prescriptionEntity, prescriptionFields.affiliate),
+      getObjectDoesntMatchError(prescription, 'affiliate.id', value => typeof value === 'number' && !!value, affiliateEntity, affiliateFields.id),
+      getNotNullError(prescription.doctor, prescriptionEntity, prescriptionFields.doctor),
+      getObjectDoesntMatchError(prescription, 'doctor.id', value => typeof value === 'number' && !!value, doctorEntity, doctorFields.id),
+      getNotNullError(prescription.medicalInsurance, prescriptionEntity, prescriptionFields.medicalInsurance),
+      getObjectDoesntMatchError(prescription, 'medicalInsurance.id', value => typeof value === 'number' && !!value, medicalInsuranceEntity, medicalInsuranceFields.id),
+      getNotNullError(prescription.norm, prescriptionEntity, prescriptionFields.norm),
+      getArrayNotEmptyError(prescription.items, prescriptionEntity, prescriptionFields.items),
+      ...getArrayDoesntMatchError(prescription.items, 'prescribed.quantity', value => typeof value === 'number' && !!value, itemEntity, itemFields.prescribed.quantity),
+      ...getArrayDoesntMatchError(prescription.items, 'prescribed.medicine.id', value => typeof value === 'number' && !!value, itemEntity, itemFields.prescribed.medicine.id),
+    ]
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = [
+      getDiferentValueError(prescription.soldDate, null, prescriptionEntity, prescriptionFields.soldDate),
+      getDiferentValueError(prescription.auditedDate, null, prescriptionEntity, prescriptionFields.auditedDate),
+    ]
+    return errors
+  },
 }
 const CANCELLED = {
-    status: 'CANCELADA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getDiferentValueError(prescription.status, ISSUED.status, prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        const errors = ISSUED.getErrors(prescription)
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
-    }
+  status: 'CANCELADA',
+  validate: validator,
+  getStatusError: prescription => getDiferentValueError(prescription.status, ISSUED.status, prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    const errors = ISSUED.getErrors(prescription)
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const CONFIRMED = {
-    status: 'CONFIRMADA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getDiferentValueError(prescription.status, ISSUED.status, prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        const errors = ISSUED.getErrors(prescription)
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
-    }
+  status: 'CONFIRMADA',
+  validate: validator,
+  getStatusError: prescription => getDiferentValueError(prescription.status, ISSUED.status, prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    const errors = ISSUED.getErrors(prescription)
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const EXPIRED = {
-    status: 'VENCIDA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getDiferentValueError(prescription.status, CONFIRMED.status, prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        const errors = CONFIRMED.getErrors(prescription)
-        //TODO: Agregar validaciones para pasar a VENCIDA
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
-    }
+  status: 'VENCIDA',
+  validate: validator,
+  getStatusError: prescription => getDiferentValueError(prescription.status, CONFIRMED.status, prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    const errors = CONFIRMED.getErrors(prescription)
+    // TODO: Agregar validaciones para pasar a VENCIDA
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const RECEIVED = {
-    status: 'RECEPCIONADA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getValueNotInListError(prescription.status, [CONFIRMED.status, PARTIALLY_RECEIVED.status], prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        let errors = []
-        if (prescription.status === CONFIRMED.status){
-            errors = CONFIRMED.getErrors(prescription)
-        }
-        if (prescription.status === PARTIALLY_RECEIVED.status){
-            errors = PARTIALLY_RECEIVED.getErrors(prescription)
-        }
-        //TODO: Agregar validaciones para pasar a RECEPCIONADA
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
+  status: 'RECEPCIONADA',
+  validate: validator,
+  getStatusError: prescription => getValueNotInListError(prescription.status, [CONFIRMED.status, PARTIALLY_RECEIVED.status], prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    let errors = []
+    if (prescription.status === CONFIRMED.status) {
+      errors = CONFIRMED.getErrors(prescription)
     }
+    if (prescription.status === PARTIALLY_RECEIVED.status) {
+      errors = PARTIALLY_RECEIVED.getErrors(prescription)
+    }
+    // TODO: Agregar validaciones para pasar a RECEPCIONADA
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const PARTIALLY_RECEIVED = {
-    status: 'PARCIALMENTE_RECEPCIONADA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getDiferentValueError(prescription.status, CONFIRMED.status, prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        const errors = CONFIRMED.getErrors(prescription)
-        //TODO: Agregar validaciones para pasar a PARCIALMENTE_RECEPCIONADAS
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
-    }
+  status: 'PARCIALMENTE_RECEPCIONADA',
+  validate: validator,
+  getStatusError: prescription => getDiferentValueError(prescription.status, CONFIRMED.status, prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    const errors = CONFIRMED.getErrors(prescription)
+    // TODO: Agregar validaciones para pasar a PARCIALMENTE_RECEPCIONADAS
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const INCOMPLETE = {
-    status: 'INCOMPLETA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getDiferentValueError(prescription.status, PARTIALLY_RECEIVED.status, prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        const errors = PARTIALLY_RECEIVED.getErrors(prescription)
-        //TODO: Agregar validaciones para pasar a INCOMPLETA
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
-    }
+  status: 'INCOMPLETA',
+  validate: validator,
+  getStatusError: prescription => getDiferentValueError(prescription.status, PARTIALLY_RECEIVED.status, prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    const errors = PARTIALLY_RECEIVED.getErrors(prescription)
+    // TODO: Agregar validaciones para pasar a INCOMPLETA
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const AUDITED = {
-    status: 'AUDITADA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        let errors = []
-        if (prescription.status === INCOMPLETE.status){
-            errors = INCOMPLETE.getErrors(prescription)
-        }
-        if (prescription.status === RECEIVED.status){
-            errors = RECEIVED.getErrors(prescription)
-        }
-        //TODO: Agregar validaciones para pasar a INCOMPLETA
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
+  status: 'AUDITADA',
+  validate: validator,
+  getStatusError: prescription => getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    let errors = []
+    if (prescription.status === INCOMPLETE.status) {
+      errors = INCOMPLETE.getErrors(prescription)
     }
+    if (prescription.status === RECEIVED.status) {
+      errors = RECEIVED.getErrors(prescription)
+    }
+    // TODO: Agregar validaciones para pasar a INCOMPLETA
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const REJECTED = {
-    status: 'RECHAZADA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        let errors = []
-        if (prescription.status === INCOMPLETE.status){
-            errors = INCOMPLETE.getErrors(prescription)
-        }
-        if (prescription.status === RECEIVED.status){
-            errors = RECEIVED.getErrors(prescription)
-        }
-        //TODO: Agregar validaciones para pasar a RECHAZADA
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
+  status: 'RECHAZADA',
+  validate: validator,
+  getStatusError: prescription => getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    let errors = []
+    if (prescription.status === INCOMPLETE.status) {
+      errors = INCOMPLETE.getErrors(prescription)
     }
+    if (prescription.status === RECEIVED.status) {
+      errors = RECEIVED.getErrors(prescription)
+    }
+    // TODO: Agregar validaciones para pasar a RECHAZADA
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const PARTIALLY_REJECTED = {
-    status: 'PARCIALMENTE_RECHAZADA',
-    validate: validator,
-    getStatusError: (prescription) => {
-        return getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status)
-    },
-    getErrors: (prescription) => {
-        let errors = []
-        if (prescription.status === INCOMPLETE.status){
-            errors = INCOMPLETE.getErrors(prescription)
-        }
-        if (prescription.status === RECEIVED.status){
-            errors = RECEIVED.getErrors(prescription)
-        }
-        //TODO: Agregar validaciones para pasar a PARCIALMENTE_RECHAZADA
-        return errors
-    },
-    getSpecificErrors: (prescription) => {
-        const errors = []
-        return errors
+  status: 'PARCIALMENTE_RECHAZADA',
+  validate: validator,
+  getStatusError: prescription => getValueNotInListError(prescription.status, [INCOMPLETE.status, RECEIVED.status], prescriptionEntity, prescriptionFields.status),
+  getErrors: (prescription) => {
+    let errors = []
+    if (prescription.status === INCOMPLETE.status) {
+      errors = INCOMPLETE.getErrors(prescription)
     }
+    if (prescription.status === RECEIVED.status) {
+      errors = RECEIVED.getErrors(prescription)
+    }
+    // TODO: Agregar validaciones para pasar a PARCIALMENTE_RECHAZADA
+    return errors
+  },
+  getSpecificErrors: (prescription) => {
+    const errors = []
+    return errors
+  },
 }
 const states = {
-    ISSUED,
-    CANCELLED,
-    CONFIRMED,
-    EXPIRED,
-    RECEIVED,
-    PARTIALLY_RECEIVED,
-    INCOMPLETE,
-    AUDITED,
-    REJECTED,
-    PARTIALLY_REJECTED
+  ISSUED,
+  CANCELLED,
+  CONFIRMED,
+  EXPIRED,
+  RECEIVED,
+  PARTIALLY_RECEIVED,
+  INCOMPLETE,
+  AUDITED,
+  REJECTED,
+  PARTIALLY_REJECTED,
 }
 
-module.exports = {states}
+module.exports = { states }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -2,169 +2,177 @@ const _object = require('lodash/object')
 const _array = require('lodash/array')
 
 const error = {
-    code: '', //codigo de error
-    message: '', //mensaje descriptivo del error
-    status: undefined, //statusCode, para web
-    cause: null //causa del error (se va a crear un handler para esto para transformar la causa a algo estándar)
+  code: '', // codigo de error
+  message: '', // mensaje descriptivo del error
+  status: undefined, // statusCode, para web
+  cause: null, // causa del error (se va a crear un handler para esto para transformar la causa a algo estándar)
 }
 
 const causes = {
-    FIELD_CAUSE: 'FIELD_CAUSE'
+  FIELD_CAUSE: 'FIELD_CAUSE',
 }
 
 const errors = {
-    UNEXPECTED_ERROR: {...error, code: "0-000", message: "Unexpected error ocurred", status: 500},
-    GENERIC_ERROR: {...error, code: "0-001", message: "Ups something went wrong"},
-    DUPLICATED_VALUE_ERROR: {...error, code: "1-000", message: "Duplicated field values"},
-    NULL_OR_EMPTY_VALUE_ERROR: {...error, code: "1-001", message: "Null or empty field value"},
-    INVALID_VALUE_ERROR: {...error, code: "1-002", message: "Invalid field value"},
-    ENTITY_ALREADY_CREATED: {...error, code: "1-003", message: "Entity already created"},
-    NOT_FOUND_ERROR: {...error, code: "1-100", message: "Not found", status: 404},
-    BAD_REQUEST: {...error, code: "1-101", message: "Please verify the payload and try again", status: 400},
-    INVALID_USERNAME_OR_PASSWORD_ERROR: {...error, code: "2-000", message: "Invalid username or password", status: 401},
-    SESSION_EXPIRED_ERROR: {...error, code: "2-001", message: "Your session has expired", status: 403},
-    FORBIDDEN_RESOURCE_EXCEPTION: {...error, code: "2-002", message: "You can´t perform that action", status: 403}
+  UNEXPECTED_ERROR: {
+    ...error, code: '0-000', message: 'Unexpected error ocurred', status: 500,
+  },
+  GENERIC_ERROR: { ...error, code: '0-001', message: 'Ups something went wrong' },
+  DUPLICATED_VALUE_ERROR: { ...error, code: '1-000', message: 'Duplicated field values' },
+  NULL_OR_EMPTY_VALUE_ERROR: { ...error, code: '1-001', message: 'Null or empty field value' },
+  INVALID_VALUE_ERROR: { ...error, code: '1-002', message: 'Invalid field value' },
+  ENTITY_ALREADY_CREATED: { ...error, code: '1-003', message: 'Entity already created' },
+  NOT_FOUND_ERROR: {
+    ...error, code: '1-100', message: 'Not found', status: 404,
+  },
+  BAD_REQUEST: {
+    ...error, code: '1-101', message: 'Please verify the payload and try again', status: 400,
+  },
+  INVALID_USERNAME_OR_PASSWORD_ERROR: {
+    ...error, code: '2-000', message: 'Invalid username or password', status: 401,
+  },
+  SESSION_EXPIRED_ERROR: {
+    ...error, code: '2-001', message: 'Your session has expired', status: 403,
+  },
+  FORBIDDEN_RESOURCE_EXCEPTION: {
+    ...error, code: '2-002', message: 'You can´t perform that action', status: 403,
+  },
 }
 
 const newError = (type, message, cause, status) => {
-    let anError = {...errors[type]}
-    anError.message = message || anError.message
-    anError.status = status || anError.status
-    anError.cause = cause || null
-    return anError
+  const anError = { ...errors[type] }
+  anError.message = message || anError.message
+  anError.status = status || anError.status
+  anError.cause = cause || null
+  return anError
 }
 
-const isBusinessError = (error) => {
-    return error && (error.code || error.length)
-}
+const isBusinessError = error => error && (error.code || error.length)
 
-const newUnexpectedError = (message, cause, status) => {return newError('UNEXPECTED_ERROR', message, cause, status)}
-const newGenericError = (message, cause, status) => {return newError('GENERIC_ERROR', message, cause, status)}
-const newDuplicatedValueError = (message, cause, status) => {return newError('DUPLICATED_VALUE_ERROR', message, cause, status)}
-const newNullOrEmptyError = (message, cause, status) => {return newError('NULL_OR_EMPTY_VALUE_ERROR', message, cause, status)}
-const newInvalidValueError = (message, cause, status) => {return newError('INVALID_VALUE_ERROR', message, cause, status)}
-const newEntityAlreadyCreated = (message, cause, status) => {return newError('ENTITY_ALREADY_CREATED', message, cause, status)}
-const newNotFoundError = (message, cause, status) => {return newError('NOT_FOUND_ERROR', message, cause, status)}
-const newBadRequestError = (message, cause, status) => {return newError('BAD_REQUEST', message, cause, status)}
-const newInvalidUsernameOrPasswordError = (message, cause, status) => {return newError('INVALID_USERNAME_OR_PASSWORD_ERROR', message, cause, status)}
-const newSessionExpiredError = (message, cause, status) => {return newError('SESSION_EXPIRED_ERROR', message, cause, status)}
-const newForbiddenResourceException = (message, cause, status) => {return newError('FORBIDDEN_RESOURCE_EXCEPTION', message, cause, status)}
+const newUnexpectedError = (message, cause, status) => newError('UNEXPECTED_ERROR', message, cause, status)
+const newGenericError = (message, cause, status) => newError('GENERIC_ERROR', message, cause, status)
+const newDuplicatedValueError = (message, cause, status) => newError('DUPLICATED_VALUE_ERROR', message, cause, status)
+const newNullOrEmptyError = (message, cause, status) => newError('NULL_OR_EMPTY_VALUE_ERROR', message, cause, status)
+const newInvalidValueError = (message, cause, status) => newError('INVALID_VALUE_ERROR', message, cause, status)
+const newEntityAlreadyCreated = (message, cause, status) => newError('ENTITY_ALREADY_CREATED', message, cause, status)
+const newNotFoundError = (message, cause, status) => newError('NOT_FOUND_ERROR', message, cause, status)
+const newBadRequestError = (message, cause, status) => newError('BAD_REQUEST', message, cause, status)
+const newInvalidUsernameOrPasswordError = (message, cause, status) => newError('INVALID_USERNAME_OR_PASSWORD_ERROR', message, cause, status)
+const newSessionExpiredError = (message, cause, status) => newError('SESSION_EXPIRED_ERROR', message, cause, status)
+const newForbiddenResourceException = (message, cause, status) => newError('FORBIDDEN_RESOURCE_EXCEPTION', message, cause, status)
 
 const generateFieldCause = (entity, field, actualValue, expectedValue) => {
-    const cause = {
-        type: causes.FIELD_CAUSE,
-        entity,
-        field
-    }
-    if (actualValue !== undefined){
-        cause.actualValue = actualValue
-    }
-    if (expectedValue !== undefined){
-        cause.expectedValue = expectedValue
-    }
-    return cause
+  const cause = {
+    type: causes.FIELD_CAUSE,
+    entity,
+    field,
+  }
+  if (actualValue !== undefined) {
+    cause.actualValue = actualValue
+  }
+  if (expectedValue !== undefined) {
+    cause.expectedValue = expectedValue
+  }
+  return cause
 }
 const generateIndexFieldCause = (entity, field, index, actualValue, expectedValue) => {
-    const cause = generateFieldCause(entity, field, actualValue, expectedValue)
-    cause.index = index
-    return cause
+  const cause = generateFieldCause(entity, field, actualValue, expectedValue)
+  cause.index = index
+  return cause
 }
 
 const getBeNullError = (value, entity, field, message) => {
-    if (value){
-        return newInvalidValueError(message || `${entity} ${field} must be null`, generateFieldCause(entity, field, value))
-    }
-    return null
+  if (value) {
+    return newInvalidValueError(message || `${entity} ${field} must be null`, generateFieldCause(entity, field, value))
+  }
+  return null
 }
 const getNotNullError = (value, entity, field, message) => {
-    if (!value){
-        return newNullOrEmptyError(message || `${entity} must have a value at ${field}`, generateFieldCause(entity, field, value))
-    }
-    return null
+  if (!value) {
+    return newNullOrEmptyError(message || `${entity} must have a value at ${field}`, generateFieldCause(entity, field, value))
+  }
+  return null
 }
 const getObjectNotEmptyError = (value, entity, field, message) => {
-    if (value instanceof Object){
-        if (!Object.keys(value).length){
-            return newNullOrEmptyError(message || `${entity} must have at list one attribute on ${field}`, generateFieldCause(entity, field, value))
-        }
-    } else {
-        return newInvalidValueError(message || `${entity} ${field} must be {}`, generateFieldCause(entity, field, value, {}))
+  if (value instanceof Object) {
+    if (!Object.keys(value).length) {
+      return newNullOrEmptyError(message || `${entity} must have at list one attribute on ${field}`, generateFieldCause(entity, field, value))
     }
-    return null
+  } else {
+    return newInvalidValueError(message || `${entity} ${field} must be {}`, generateFieldCause(entity, field, value, {}))
+  }
+  return null
 }
 const getArrayNotEmptyError = (value, entity, field, message) => {
-    if (value instanceof Array){
-        if (!value.length){
-            return newNullOrEmptyError(message || `${entity} must have at list one value at ${field}`, generateFieldCause(entity, field, value))
-        }
-    } else {
-        return newInvalidValueError(message || `${entity} ${field} must be []`, generateFieldCause(entity, field, value, []))
+  if (value instanceof Array) {
+    if (!value.length) {
+      return newNullOrEmptyError(message || `${entity} must have at list one value at ${field}`, generateFieldCause(entity, field, value))
     }
-    return null
+  } else {
+    return newInvalidValueError(message || `${entity} ${field} must be []`, generateFieldCause(entity, field, value, []))
+  }
+  return null
 }
 const getDiferentValueError = (value, otherValue, entity, field, message) => {
-    if (value !== otherValue){
-        return newInvalidValueError(message || `${entity} ${field} must be ${otherValue}`, generateFieldCause(entity, field, value, otherValue))
-    }
-    return null
+  if (value !== otherValue) {
+    return newInvalidValueError(message || `${entity} ${field} must be ${otherValue}`, generateFieldCause(entity, field, value, otherValue))
+  }
+  return null
 }
 const getValueNotInListError = (value, otherValues, entity, field, message) => {
-    const found = otherValues.find((aValue) => {
-        return aValue === value
-    })
-    if (!found){
-        return newInvalidValueError(message || `${entity} ${field} must be one of this ${otherValues}`, generateFieldCause(entity, field, value, otherValues))
-    }
-    return null
+  const found = otherValues.find(aValue => aValue === value)
+  if (!found) {
+    return newInvalidValueError(message || `${entity} ${field} must be one of this ${otherValues}`, generateFieldCause(entity, field, value, otherValues))
+  }
+  return null
 }
 
 const getObjectDoesntMatchError = (object, path, isValidValue, entity, field, nullMessage, invalidValueMessage) => {
-    if (!_object.has(object, path)){
-        return newNullOrEmptyError(nullMessage || `${entity} must have a value at ${field}`, generateFieldCause(entity, field))
-    }
-    const actualValue = _object.get(object, path)
-    if (!isValidValue(actualValue)){
-        return newInvalidValueError(invalidValueMessage || `${entity} ${field} has an invalid value`, generateFieldCause(entity, field, actualValue))
-    }
-    return null
+  if (!_object.has(object, path)) {
+    return newNullOrEmptyError(nullMessage || `${entity} must have a value at ${field}`, generateFieldCause(entity, field))
+  }
+  const actualValue = _object.get(object, path)
+  if (!isValidValue(actualValue)) {
+    return newInvalidValueError(invalidValueMessage || `${entity} ${field} has an invalid value`, generateFieldCause(entity, field, actualValue))
+  }
+  return null
 }
 
 const getArrayDoesntMatchError = (array, path, isValidValue, entity, field, nullMessage, invalidValueMessage) => {
-    const errors = _array.compact(array.map((element, index) => {
-        if (!_object.has(element, path)){
-            return newNullOrEmptyError(nullMessage || `${entity} must have a value at ${field}`, generateIndexFieldCause(entity, field, index))
-        }
-        const actualValue = _object.get(element, path)
-        if (!isValidValue(actualValue)){
-            return newInvalidValueError(invalidValueMessage || `${entity} ${field} has an invalid value`, generateIndexFieldCause(entity, field, index, actualValue))
-        }
-    }))
-    return errors
+  const errors = _array.compact(array.map((element, index) => {
+    if (!_object.has(element, path)) {
+      return newNullOrEmptyError(nullMessage || `${entity} must have a value at ${field}`, generateIndexFieldCause(entity, field, index))
+    }
+    const actualValue = _object.get(element, path)
+    if (!isValidValue(actualValue)) {
+      return newInvalidValueError(invalidValueMessage || `${entity} ${field} has an invalid value`, generateIndexFieldCause(entity, field, index, actualValue))
+    }
+  }))
+  return errors
 }
 
 module.exports = {
-    _errors: errors,
-    newUnexpectedError,
-    newGenericError,
-    newDuplicatedValueError,
-    newNullOrEmptyError,
-    newInvalidValueError,
-    newEntityAlreadyCreated,
-    newNotFoundError,
-    newBadRequestError,
-    newInvalidUsernameOrPasswordError,
-    newSessionExpiredError,
-    newForbiddenResourceException,
-    _causes: causes,
-    generateFieldCause,
-    generateIndexFieldCause,
-    getArrayNotEmptyError,
-    getDiferentValueError,
-    getNotNullError,
-    getObjectNotEmptyError,
-    getValueNotInListError,
-    getBeNullError,
-    getObjectDoesntMatchError,
-    getArrayDoesntMatchError,
-    isBusinessError
+  _errors: errors,
+  newUnexpectedError,
+  newGenericError,
+  newDuplicatedValueError,
+  newNullOrEmptyError,
+  newInvalidValueError,
+  newEntityAlreadyCreated,
+  newNotFoundError,
+  newBadRequestError,
+  newInvalidUsernameOrPasswordError,
+  newSessionExpiredError,
+  newForbiddenResourceException,
+  _causes: causes,
+  generateFieldCause,
+  generateIndexFieldCause,
+  getArrayNotEmptyError,
+  getDiferentValueError,
+  getNotNullError,
+  getObjectNotEmptyError,
+  getValueNotInListError,
+  getBeNullError,
+  getObjectDoesntMatchError,
+  getArrayDoesntMatchError,
+  isBusinessError,
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,21 +1,22 @@
 const winston = require('winston')
 const moment = require('moment')
+
 const logger = winston.createLogger({
   transports: [new winston.transports.Console()],
   format: winston.format.combine(
     winston.format.colorize(),
     winston.format.simple(),
     winston.format.timestamp({
-      format: 'YYYY-MM-DD HH:mm:ss'
+      format: 'YYYY-MM-DD HH:mm:ss',
     }),
-    winston.format.printf(info => `${info.level} ${info.timestamp}: ${info.message}`)
-  )
+    winston.format.printf(info => `${info.level} ${info.timestamp}: ${info.message}`),
+  ),
 })
 
 const formats = {
   dateTimeFormat: 'DD/MM/YYYY HH:mm',
   dateFormat: 'DD/MM/YYYY',
-  timeFormat: 'HH:mm'
+  timeFormat: 'HH:mm',
 }
 
 const formatter = {
@@ -31,38 +32,35 @@ const formatter = {
   toDate: (date, formatter) => {
     if (moment.isMoment(date)) {
       return date
-    } else {
-      date = moment(date, formatter)
-      if (!date.isValid()) {
-        date = null
-      }
-      return date
     }
-  }
+    date = moment(date, formatter)
+    if (!date.isValid()) {
+      date = null
+    }
+    return date
+  },
 }
 
 const dateTimeFormat = {
-  toString: (date) => { return formatter.toString(date, formats.dateTimeFormat) },
-  toDate: (date) => { return formatter.toDate(date, formats.dateTimeFormat) }
+  toString: date => formatter.toString(date, formats.dateTimeFormat),
+  toDate: date => formatter.toDate(date, formats.dateTimeFormat),
 }
 const dateFormat = {
-  toString: (date) => { return formatter.toString(date, formats.dateFormat) },
-  toDate: (date) => { return formatter.toDate(date, formats.dateFormat) }
+  toString: date => formatter.toString(date, formats.dateFormat),
+  toDate: date => formatter.toDate(date, formats.dateFormat),
 }
 
-const generateNewSequencer = () => {
-  return {
-    actualCount: 0,
-    nextValue: function() {
-      return ++this.actualCount
-    }
-  }
-}
+const generateNewSequencer = () => ({
+  actualCount: 0,
+  nextValue() {
+    return ++this.actualCount
+  },
+})
 
 module.exports = {
   logger,
   formats,
   dateFormat,
   dateTimeFormat,
-  generateNewSequencer
+  generateNewSequencer,
 }

--- a/test/e2e/routes/doctors.spec.js
+++ b/test/e2e/routes/doctors.spec.js
@@ -4,36 +4,34 @@ const { MedicalInsuranceRepository } = require('../../../src/repositories/medica
 const { MedicalInsurance } = require('../../../src/domain/medicalInsurance')
 
 const app = init()
-app.locals.logger = {info: () => {}, error: () => {}}
+app.locals.logger = { info: () => {}, error: () => {} }
 
 describe('when do a get in /medical-insurances', () => {
   describe('and the repository response ok', () => {
     const medicalInsurancesValue = [
       MedicalInsurance.fromObject({
         id: 0,
-        description: 'OSDE'
+        description: 'OSDE',
       }),
       MedicalInsurance.fromObject({
         id: 1,
-        description: 'SWISS MEDICAL'
-      })
+        description: 'SWISS MEDICAL',
+      }),
     ]
 
     beforeAll(() => {
       MedicalInsuranceRepository.medicalInsurances = medicalInsurancesValue
     })
 
-    it('return all avaiables the medicalInsurances', () => {
-      return request(app)
-        .get('/medical-insurances')
-        .expect(200)
-        .then(res => {
-          const firstMedicalInsurance = res.body[0]
-          expect(firstMedicalInsurance).toHaveProperty('id')
-          expect(firstMedicalInsurance).toHaveProperty('description')
-          expect(res.body).toEqual(medicalInsurancesValue)
-        })
-    })
+    it('return all avaiables the medicalInsurances', () => request(app)
+      .get('/medical-insurances')
+      .expect(200)
+      .then((res) => {
+        const firstMedicalInsurance = res.body[0]
+        expect(firstMedicalInsurance).toHaveProperty('id')
+        expect(firstMedicalInsurance).toHaveProperty('description')
+        expect(res.body).toEqual(medicalInsurancesValue)
+      }))
   })
 
   describe('and the repository fails on search', () => {
@@ -43,23 +41,19 @@ describe('when do a get in /medical-insurances', () => {
       }
     })
 
-    it('respond with 500 ', () => {
-      return request(app)
-        .get('/medical-insurances')
-        .expect(500)
-    })
+    it('respond with 500 ', () => request(app)
+      .get('/medical-insurances')
+      .expect(500))
   })
 })
 
 describe('when do a get at /ping', () => {
-  it('respond pong', () => {
-    return request(app)
-      .get('/ping')
-      .expect(200)
-      .then(res => {
-        expect(res.body.message).toEqual('pong')
-      })
-  })
+  it('respond pong', () => request(app)
+    .get('/ping')
+    .expect(200)
+    .then((res) => {
+      expect(res.body.message).toEqual('pong')
+    }))
 })
 
 describe('when do a get in /doctors/{id}/medical-insurances', () => {
@@ -68,29 +62,27 @@ describe('when do a get in /doctors/{id}/medical-insurances', () => {
     const medicalInsurancesValue = [
       MedicalInsurance.fromObject({
         id: 0,
-        description: 'OSDE'
+        description: 'OSDE',
       }),
       MedicalInsurance.fromObject({
         id: 1,
-        description: 'SWISS MEDICAL'
-      })
+        description: 'SWISS MEDICAL',
+      }),
     ]
 
     beforeAll(() => {
       MedicalInsuranceRepository.medicalInsurances = medicalInsurancesValue
     })
 
-    it('return all avaiables the medicalInsurances for this medic', () => {
-      return request(app)
-        .get(`/doctors/${doctorId}/medical-insurances`)
-        .expect(200)
-        .then(res => {
-          const firstMedicalInsurance = res.body[0]
-          expect(firstMedicalInsurance).toHaveProperty('id')
-          expect(firstMedicalInsurance).toHaveProperty('description')
-          expect(res.body).toEqual(medicalInsurancesValue)
-        })
-    })
+    it('return all avaiables the medicalInsurances for this medic', () => request(app)
+      .get(`/doctors/${doctorId}/medical-insurances`)
+      .expect(200)
+      .then((res) => {
+        const firstMedicalInsurance = res.body[0]
+        expect(firstMedicalInsurance).toHaveProperty('id')
+        expect(firstMedicalInsurance).toHaveProperty('description')
+        expect(res.body).toEqual(medicalInsurancesValue)
+      }))
   })
 
   describe('and the repository fails on search', () => {
@@ -100,10 +92,8 @@ describe('when do a get in /doctors/{id}/medical-insurances', () => {
       }
     })
 
-    it('respond with 500 ', () => {
-      return request(app)
-        .get(`/doctors/${doctorId}/medical-insurances`)
-        .expect(500)
-    })
+    it('respond with 500 ', () => request(app)
+      .get(`/doctors/${doctorId}/medical-insurances`)
+      .expect(500))
   })
 })

--- a/test/e2e/routes/institutions.spec.js
+++ b/test/e2e/routes/institutions.spec.js
@@ -4,7 +4,7 @@ const { InstitutionRepository } = require('../../../src/repositories/institution
 const { Institution } = require('../../../src/domain/institution')
 
 const app = init()
-app.locals.logger = {info: () => {}, error: () => {}}
+app.locals.logger = { info: () => {}, error: () => {} }
 
 describe('when do a get in /institutions', () => {
   describe('and the repository response ok', () => {
@@ -12,31 +12,29 @@ describe('when do a get in /institutions', () => {
       Institution.fromObject({
         id: 0,
         description: 'Hospital Italiano',
-        address: 'La crujia'
+        address: 'La crujia',
       }),
       Institution.fromObject({
         id: 1,
         description: 'Corporacion medica',
-        address: 'Olazabal 210'
-      })
+        address: 'Olazabal 210',
+      }),
     ]
 
     beforeAll(() => {
       InstitutionRepository.institutions = institutionsValue
     })
 
-    it('return all available the institutions', () => {
-      return request(app)
-        .get('/institutions')
-        .expect(200)
-        .then(res => {
-          const firstInstitution = res.body[0]
-          expect(firstInstitution).toHaveProperty('id')
-          expect(firstInstitution).toHaveProperty('description')
-          expect(firstInstitution).toHaveProperty('address')
-          expect(res.body).toEqual(institutionsValue)
-        })
-    })
+    it('return all available the institutions', () => request(app)
+      .get('/institutions')
+      .expect(200)
+      .then((res) => {
+        const firstInstitution = res.body[0]
+        expect(firstInstitution).toHaveProperty('id')
+        expect(firstInstitution).toHaveProperty('description')
+        expect(firstInstitution).toHaveProperty('address')
+        expect(res.body).toEqual(institutionsValue)
+      }))
   })
 
   describe('and the repository fails on search', () => {
@@ -46,10 +44,8 @@ describe('when do a get in /institutions', () => {
       }
     })
 
-    it('respond with 500 ', () => {
-      return request(app)
-        .get('/institutions')
-        .expect(500)
-    })
+    it('respond with 500 ', () => request(app)
+      .get('/institutions')
+      .expect(500))
   })
 })

--- a/test/e2e/routes/medicalInsurances.spec.js
+++ b/test/e2e/routes/medicalInsurances.spec.js
@@ -4,36 +4,34 @@ const { MedicalInsuranceRepository } = require('../../../src/repositories/medica
 const { MedicalInsurance } = require('../../../src/domain/medicalInsurance')
 
 const app = init()
-app.locals.logger = {info: () => {}, error: () => {}}
+app.locals.logger = { info: () => {}, error: () => {} }
 
 describe('when do a get in /medical-insurances', () => {
   describe('and the repository response ok', () => {
     const medicalInsurancesValue = [
       MedicalInsurance.fromObject({
         id: 0,
-        description: 'OSDE'
+        description: 'OSDE',
       }),
       MedicalInsurance.fromObject({
         id: 1,
-        description: 'SWISS MEDICAL'
-      })
+        description: 'SWISS MEDICAL',
+      }),
     ]
 
     beforeAll(() => {
       MedicalInsuranceRepository.medicalInsurances = medicalInsurancesValue
     })
 
-    it('return all avaiables the medicalInsurances', () => {
-      return request(app)
-        .get('/medical-insurances')
-        .expect(200)
-        .then(res => {
-          const firstMedicalInsurance = res.body[0]
-          expect(firstMedicalInsurance).toHaveProperty('id')
-          expect(firstMedicalInsurance).toHaveProperty('description')
-          expect(res.body).toEqual(medicalInsurancesValue)
-        })
-    })
+    it('return all avaiables the medicalInsurances', () => request(app)
+      .get('/medical-insurances')
+      .expect(200)
+      .then((res) => {
+        const firstMedicalInsurance = res.body[0]
+        expect(firstMedicalInsurance).toHaveProperty('id')
+        expect(firstMedicalInsurance).toHaveProperty('description')
+        expect(res.body).toEqual(medicalInsurancesValue)
+      }))
   })
 
   describe('and the repository fails on search', () => {
@@ -43,11 +41,9 @@ describe('when do a get in /medical-insurances', () => {
       }
     })
 
-    it('respond with 500 ', () => {
-      return request(app)
-        .get('/medical-insurances')
-        .expect(500)
-    })
+    it('respond with 500 ', () => request(app)
+      .get('/medical-insurances')
+      .expect(500))
   })
 })
 
@@ -57,29 +53,27 @@ describe('when do a get in /doctors/{id}/medical-insurances', () => {
     const medicalInsurancesValue = [
       MedicalInsurance.fromObject({
         id: 0,
-        description: 'OSDE'
+        description: 'OSDE',
       }),
       MedicalInsurance.fromObject({
         id: 1,
-        description: 'SWISS MEDICAL'
-      })
+        description: 'SWISS MEDICAL',
+      }),
     ]
 
     beforeAll(() => {
       MedicalInsuranceRepository.medicalInsurances = medicalInsurancesValue
     })
 
-    it('return all avaiables the medicalInsurances for this medic', () => {
-      return request(app)
-        .get(`/doctors/${doctorId}/medical-insurances`)
-        .expect(200)
-        .then(res => {
-          const firstMedicalInsurance = res.body[0]
-          expect(firstMedicalInsurance).toHaveProperty('id')
-          expect(firstMedicalInsurance).toHaveProperty('description')
-          expect(res.body).toEqual(medicalInsurancesValue)
-        })
-    })
+    it('return all avaiables the medicalInsurances for this medic', () => request(app)
+      .get(`/doctors/${doctorId}/medical-insurances`)
+      .expect(200)
+      .then((res) => {
+        const firstMedicalInsurance = res.body[0]
+        expect(firstMedicalInsurance).toHaveProperty('id')
+        expect(firstMedicalInsurance).toHaveProperty('description')
+        expect(res.body).toEqual(medicalInsurancesValue)
+      }))
   })
 
   describe('and the repository fails on search', () => {
@@ -89,10 +83,8 @@ describe('when do a get in /doctors/{id}/medical-insurances', () => {
       }
     })
 
-    it('respond with 500 ', () => {
-      return request(app)
-        .get(`/doctors/${doctorId}/medical-insurances`)
-        .expect(500)
-    })
+    it('respond with 500 ', () => request(app)
+      .get(`/doctors/${doctorId}/medical-insurances`)
+      .expect(500))
   })
 })

--- a/test/e2e/routes/ping.spec.js
+++ b/test/e2e/routes/ping.spec.js
@@ -1,15 +1,14 @@
 const request = require('supertest')
 const { init } = require('../../../src/init/initServer')
+
 const app = init()
-app.locals.logger = {info: () => {}, error: () => {}}
+app.locals.logger = { info: () => {}, error: () => {} }
 
 describe('when do a get at /ping', () => {
-  it('respond pong', () => {
-    return request(app)
-      .get('/ping')
-      .expect(200)
-      .then(res => {
-        expect(res.body.message).toEqual('pong')
-      })
-  })
+  it('respond pong', () => request(app)
+    .get('/ping')
+    .expect(200)
+    .then((res) => {
+      expect(res.body.message).toEqual('pong')
+    }))
 })

--- a/test/unit/dominio/affiliate.spec.js
+++ b/test/unit/dominio/affiliate.spec.js
@@ -31,195 +31,193 @@ const toDate = '17/08/1997'
 const code = '800006 0980565'
 const category = '01'
 const imageCredential = '/credentialPedro.jpg'
-const plan = new Plan({ idPlan, description, entryDate, leavingDate, percentage, idMedicalInsurance })
+const plan = new Plan({
+  idPlan, description, entryDate, leavingDate, percentage, idMedicalInsurance,
+})
 
 const testerAffiliate = {
-    id, idPatient, name, surname, userName, birthDate, gender, contactNumber, email, address, nationality, nicNumber, nicIssueDate, nicType, nicExemplary, nicPhoto, fromDate, toDate, code, category, imageCredential, plan
+  id, idPatient, name, surname, userName, birthDate, gender, contactNumber, email, address, nationality, nicNumber, nicIssueDate, nicType, nicExemplary, nicPhoto, fromDate, toDate, code, category, imageCredential, plan,
 }
 
 describe('Affiliate', () => {
-    let affiliate = new Affiliate()
+  let affiliate = new Affiliate()
 
-    beforeEach(() => {
-        affiliate = new Affiliate()
-    })
+  beforeEach(() => {
+    affiliate = new Affiliate()
+  })
 
-    it('has all this properties', () => {
-        expect(affiliate).toHaveProperty('id')
-        expect(affiliate).toHaveProperty('idPatient')
-        expect(affiliate).toHaveProperty('name')
-        expect(affiliate).toHaveProperty('surname')
-        expect(affiliate).toHaveProperty('userName')
-        expect(affiliate).toHaveProperty('birthDate')
-        expect(affiliate).toHaveProperty('gender')
-        expect(affiliate).toHaveProperty('contactNumber')
-        expect(affiliate).toHaveProperty('email')
-        expect(affiliate).toHaveProperty('address')
-        expect(affiliate).toHaveProperty('nationality')
-        expect(affiliate).toHaveProperty('nicNumber')
-        expect(affiliate).toHaveProperty('nicIssueDate')
-        expect(affiliate).toHaveProperty('nicType')
-        expect(affiliate).toHaveProperty('nicExemplary')
-        expect(affiliate).toHaveProperty('nicPhoto')
-        expect(affiliate).toHaveProperty('fromDate')
-        expect(affiliate).toHaveProperty('toDate')
-        expect(affiliate).toHaveProperty('code')
-        expect(affiliate).toHaveProperty('category')
-        expect(affiliate).toHaveProperty('imageCredential')
-        expect(affiliate).toHaveProperty('plan')
-    })
-    it('has this properties default values', () => {
-        expect(affiliate.id).toBeNull()
-        expect(affiliate.idPatient).toBeNull()
-        expect(affiliate.name).toBeNull()
-        expect(affiliate.surname).toBeNull()
-        expect(affiliate.userName).toBeNull()
-        expect(affiliate.birthDate).toBeNull()
-        expect(affiliate.gender).toBeNull()
-        expect(affiliate.contactNumber).toBeNull()
-        expect(affiliate.email).toBeNull()
-        expect(affiliate.address).toBeNull()
-        expect(affiliate.nationality).toBeNull()
-        expect(affiliate.nicNumber).toBeNull()
-        expect(affiliate.nicIssueDate).toBeNull()
-        expect(affiliate.nicType).toBeNull()
-        expect(affiliate.nicExemplary).toBeNull()
-        expect(affiliate.nicPhoto).toBeNull()
-        expect(affiliate.fromDate).toBeNull()
-        expect(affiliate.toDate).toBeNull()
-        expect(affiliate.code).toBeNull()
-        expect(affiliate.category).toBeNull()
-        expect(affiliate.imageCredential).toBeNull()
-        expect(affiliate.plan).toBeInstanceOf(Plan)
+  it('has all this properties', () => {
+    expect(affiliate).toHaveProperty('id')
+    expect(affiliate).toHaveProperty('idPatient')
+    expect(affiliate).toHaveProperty('name')
+    expect(affiliate).toHaveProperty('surname')
+    expect(affiliate).toHaveProperty('userName')
+    expect(affiliate).toHaveProperty('birthDate')
+    expect(affiliate).toHaveProperty('gender')
+    expect(affiliate).toHaveProperty('contactNumber')
+    expect(affiliate).toHaveProperty('email')
+    expect(affiliate).toHaveProperty('address')
+    expect(affiliate).toHaveProperty('nationality')
+    expect(affiliate).toHaveProperty('nicNumber')
+    expect(affiliate).toHaveProperty('nicIssueDate')
+    expect(affiliate).toHaveProperty('nicType')
+    expect(affiliate).toHaveProperty('nicExemplary')
+    expect(affiliate).toHaveProperty('nicPhoto')
+    expect(affiliate).toHaveProperty('fromDate')
+    expect(affiliate).toHaveProperty('toDate')
+    expect(affiliate).toHaveProperty('code')
+    expect(affiliate).toHaveProperty('category')
+    expect(affiliate).toHaveProperty('imageCredential')
+    expect(affiliate).toHaveProperty('plan')
+  })
+  it('has this properties default values', () => {
+    expect(affiliate.id).toBeNull()
+    expect(affiliate.idPatient).toBeNull()
+    expect(affiliate.name).toBeNull()
+    expect(affiliate.surname).toBeNull()
+    expect(affiliate.userName).toBeNull()
+    expect(affiliate.birthDate).toBeNull()
+    expect(affiliate.gender).toBeNull()
+    expect(affiliate.contactNumber).toBeNull()
+    expect(affiliate.email).toBeNull()
+    expect(affiliate.address).toBeNull()
+    expect(affiliate.nationality).toBeNull()
+    expect(affiliate.nicNumber).toBeNull()
+    expect(affiliate.nicIssueDate).toBeNull()
+    expect(affiliate.nicType).toBeNull()
+    expect(affiliate.nicExemplary).toBeNull()
+    expect(affiliate.nicPhoto).toBeNull()
+    expect(affiliate.fromDate).toBeNull()
+    expect(affiliate.toDate).toBeNull()
+    expect(affiliate.code).toBeNull()
+    expect(affiliate.category).toBeNull()
+    expect(affiliate.imageCredential).toBeNull()
+    expect(affiliate.plan).toBeInstanceOf(Plan)
+  })
 
-    })
+  it('can be transformed to json', () => {
+    expect(affiliate.toJson()).toEqual('{"id":null,"idPatient":null,"name":null,"surname":null,"userName":null,"birthDate":null,"gender":null,"contactNumber":null,"email":null,"address":null,"nationality":null,"nicNumber":null,"nicIssueDate":null,"nicType":null,"nicExemplary":null,"nicPhoto":null,"fromDate":null,"toDate":null,"code":null,"category":null,"imageCredential":null,"plan":{"id":null,"description":null,"entryDate":null,"leavingDate":null,"percentage":null,"idMedicalInsurance":null}}')
+  })
+  it('can be obtained from json', () => {
+    affiliate = Affiliate.fromJson(JSON.stringify(testerAffiliate))
+    expect(affiliate.id).toEqual(id)
+    expect(affiliate.idPatient).toEqual(idPatient)
+    expect(affiliate.name).toEqual(name)
+    expect(affiliate.surname).toEqual(surname)
+    expect(affiliate.userName).toEqual(userName)
+    expect(affiliate.getBirthDate()).toEqual(birthDate)
+    expect(affiliate.gender).toEqual(gender)
+    expect(affiliate.contactNumber).toEqual(contactNumber)
+    expect(affiliate.email).toEqual(email)
+    expect(affiliate.address).toEqual(address)
+    expect(affiliate.nationality).toEqual(nationality)
+    expect(affiliate.nicNumber).toEqual(nicNumber)
+    expect(affiliate.getNicIssueDate()).toEqual(nicIssueDate)
+    expect(affiliate.nicType).toEqual(nicType)
+    expect(affiliate.nicExemplary).toEqual(nicExemplary)
+    expect(affiliate.nicPhoto).toEqual(nicPhoto)
+    expect(affiliate.getFromDate()).toEqual(fromDate)
+    expect(affiliate.getToDate()).toEqual(toDate)
+    expect(affiliate.code).toEqual(code)
+    expect(affiliate.category).toEqual(category)
+    expect(affiliate.imageCredential).toEqual(imageCredential)
+    expect(affiliate.plan).toEqual(plan)
+  })
 
-    it('can be transformed to json', () => {
-        expect(affiliate.toJson()).toEqual("{\"id\":null,\"idPatient\":null,\"name\":null,\"surname\":null,\"userName\":null,\"birthDate\":null,\"gender\":null,\"contactNumber\":null,\"email\":null,\"address\":null,\"nationality\":null,\"nicNumber\":null,\"nicIssueDate\":null,\"nicType\":null,\"nicExemplary\":null,\"nicPhoto\":null,\"fromDate\":null,\"toDate\":null,\"code\":null,\"category\":null,\"imageCredential\":null,\"plan\":{\"id\":null,\"description\":null,\"entryDate\":null,\"leavingDate\":null,\"percentage\":null,\"idMedicalInsurance\":null}}")
-    })
-    it('can be obtained from json', () => {
-        affiliate = Affiliate.fromJson(JSON.stringify(testerAffiliate))
-        expect(affiliate.id).toEqual(id)
-        expect(affiliate.idPatient).toEqual(idPatient)
-        expect(affiliate.name).toEqual(name)
-        expect(affiliate.surname).toEqual(surname)
-        expect(affiliate.userName).toEqual(userName)
-        expect(affiliate.getBirthDate()).toEqual(birthDate)
-        expect(affiliate.gender).toEqual(gender)
-        expect(affiliate.contactNumber).toEqual(contactNumber)
-        expect(affiliate.email).toEqual(email)
-        expect(affiliate.address).toEqual(address)
-        expect(affiliate.nationality).toEqual(nationality)
-        expect(affiliate.nicNumber).toEqual(nicNumber)
-        expect(affiliate.getNicIssueDate()).toEqual(nicIssueDate)
-        expect(affiliate.nicType).toEqual(nicType)
-        expect(affiliate.nicExemplary).toEqual(nicExemplary)
-        expect(affiliate.nicPhoto).toEqual(nicPhoto)
-        expect(affiliate.getFromDate()).toEqual(fromDate)
-        expect(affiliate.getToDate()).toEqual(toDate)
-        expect(affiliate.code).toEqual(code)
-        expect(affiliate.category).toEqual(category)
-        expect(affiliate.imageCredential).toEqual(imageCredential)
-        expect(affiliate.plan).toEqual(plan)
+  // Testing atributtes of date =D
+  it('when you set a valid birth date to a affiliate it stores it like a moment', () => {
+    const birthDate = '12/03/1992'
+    expect(affiliate.birthDate).toBeNull()
+    affiliate.setBirthDate(birthDate)
+    expect(moment.isMoment(affiliate.birthDate)).toBeTruthy()
+    expect(affiliate.birthDate.format(formats.dateFormat)).toEqual(birthDate)
+  })
+  it('when you set a valid Nic Issue date to a affiliate it stores it like a moment', () => {
+    const nicIssueDate = '11/02/1991'
+    expect(affiliate.nicIssueDate).toBeNull()
+    affiliate.setNicIssueDate(nicIssueDate)
+    expect(moment.isMoment(affiliate.nicIssueDate)).toBeTruthy()
+    expect(affiliate.nicIssueDate.format(formats.dateFormat)).toEqual(nicIssueDate)
+  })
 
-    })
+  it('when you set a valid from date to a affiliate it stores it like a moment', () => {
+    const fromDate = '10/11/1990'
+    expect(affiliate.fromDate).toBeNull()
+    affiliate.setFromDate(fromDate)
+    expect(moment.isMoment(affiliate.fromDate)).toBeTruthy()
+    expect(affiliate.fromDate.format(formats.dateFormat)).toEqual(fromDate)
+  })
+  it('when you set a valid to date to a affiliate it stores it like a moment', () => {
+    const toDate = '10/11/1999'
+    expect(affiliate.toDate).toBeNull()
+    affiliate.setToDate(toDate)
+    expect(moment.isMoment(affiliate.toDate)).toBeTruthy()
+    expect(affiliate.toDate.format(formats.dateFormat)).toEqual(toDate)
+  })
 
-    // Testing atributtes of date =D
-    it('when you set a valid birth date to a affiliate it stores it like a moment', () => {
-        const birthDate = '12/03/1992'
-        expect(affiliate.birthDate).toBeNull()
-        affiliate.setBirthDate(birthDate)
-        expect(moment.isMoment(affiliate.birthDate)).toBeTruthy()
-        expect(affiliate.birthDate.format(formats.dateFormat)).toEqual(birthDate)
-    })
-    it('when you set a valid Nic Issue date to a affiliate it stores it like a moment', () => {
-        const nicIssueDate = '11/02/1991'
-        expect(affiliate.nicIssueDate).toBeNull()
-        affiliate.setNicIssueDate(nicIssueDate)
-        expect(moment.isMoment(affiliate.nicIssueDate)).toBeTruthy()
-        expect(affiliate.nicIssueDate.format(formats.dateFormat)).toEqual(nicIssueDate)
-    })
+  it('when you set an invalid birth date to a affiliate it stores a null', () => {
+    const birthDate = '40/02/1998'
+    expect(affiliate.birthDate).toBeNull()
+    affiliate.setBirthDate(birthDate)
+    expect(affiliate.birthDate).toBeNull()
+  })
+  it('when you set an invalid Nic Issue date to a affiliate it stores a null', () => {
+    const nicIssueDate = '50/02/1998'
+    expect(affiliate.nicIssueDate).toBeNull()
+    affiliate.setNicIssueDate(nicIssueDate)
+    expect(affiliate.nicIssueDate).toBeNull()
+  })
+  it('when you set an from date to a affiliate it stores a null', () => {
+    const fromDate = '50/03/1998'
+    expect(affiliate.fromDate).toBeNull()
+    affiliate.setFromDate(fromDate)
+    expect(affiliate.fromDate).toBeNull()
+  })
+  it('when you set an to date to a affiliate it stores a null', () => {
+    const toDate = '60/03/1998'
+    expect(affiliate.toDate).toBeNull()
+    affiliate.setToDate(toDate)
+    expect(affiliate.toDate).toBeNull()
+  })
 
-    it('when you set a valid from date to a affiliate it stores it like a moment', () => {
-        const fromDate = '10/11/1990'
-        expect(affiliate.fromDate).toBeNull()
-        affiliate.setFromDate(fromDate)
-        expect(moment.isMoment(affiliate.fromDate)).toBeTruthy()
-        expect(affiliate.fromDate.format(formats.dateFormat)).toEqual(fromDate)
-    })
-    it('when you set a valid to date to a affiliate it stores it like a moment', () => {
-        const toDate = '10/11/1999'
-        expect(affiliate.toDate).toBeNull()
-        affiliate.setToDate(toDate)
-        expect(moment.isMoment(affiliate.toDate)).toBeTruthy()
-        expect(affiliate.toDate.format(formats.dateFormat)).toEqual(toDate)
-    })
+  it('when you get the birth date from a affiliate that has an birth date it returns a string representation', () => {
+    const birthDate = '21/01/1998'
+    affiliate.setBirthDate(birthDate)
+    expect(affiliate.getBirthDate()).toEqual(birthDate)
+  })
+  it('when you get the nic Issue date from a affiliate that has an  nic Issue date it returns a string representation', () => {
+    const nicIssueDate = '21/01/1998'
+    affiliate.setNicIssueDate(nicIssueDate)
+    expect(affiliate.getNicIssueDate()).toEqual(nicIssueDate)
+  })
 
-    it('when you set an invalid birth date to a affiliate it stores a null', () => {
-        const birthDate = '40/02/1998'
-        expect(affiliate.birthDate).toBeNull()
-        affiliate.setBirthDate(birthDate)
-        expect(affiliate.birthDate).toBeNull()
-    })
-    it('when you set an invalid Nic Issue date to a affiliate it stores a null', () => {
-        const nicIssueDate = '50/02/1998'
-        expect(affiliate.nicIssueDate).toBeNull()
-        affiliate.setNicIssueDate(nicIssueDate)
-        expect(affiliate.nicIssueDate).toBeNull()
-    })
-    it('when you set an from date to a affiliate it stores a null', () => {
-        const fromDate = '50/03/1998'
-        expect(affiliate.fromDate).toBeNull()
-        affiliate.setFromDate(fromDate)
-        expect(affiliate.fromDate).toBeNull()
-    })
-    it('when you set an to date to a affiliate it stores a null', () => {
-        const toDate = '60/03/1998'
-        expect(affiliate.toDate).toBeNull()
-        affiliate.setToDate(toDate)
-        expect(affiliate.toDate).toBeNull()
-    })
+  it('when you get the from date from a affiliate that has an  from date it returns a string representation', () => {
+    const fromDate = '21/01/1998'
+    affiliate.setFromDate(fromDate)
+    expect(affiliate.getFromDate()).toEqual(fromDate)
+  })
 
-    it('when you get the birth date from a affiliate that has an birth date it returns a string representation', () => {
-        const birthDate = '21/01/1998'
-        affiliate.setBirthDate(birthDate)
-        expect(affiliate.getBirthDate()).toEqual(birthDate)
-    })
-    it('when you get the nic Issue date from a affiliate that has an  nic Issue date it returns a string representation', () => {
-        const nicIssueDate = '21/01/1998'
-        affiliate.setNicIssueDate(nicIssueDate)
-        expect(affiliate.getNicIssueDate()).toEqual(nicIssueDate)
-    })
+  it('when you get the to date from a affiliate that has an  to date it returns a string representation', () => {
+    const toDate = '21/01/1998'
+    affiliate.setToDate(toDate)
+    expect(affiliate.getToDate()).toEqual(toDate)
+  })
 
-    it('when you get the from date from a affiliate that has an  from date it returns a string representation', () => {
-        const fromDate = '21/01/1998'
-        affiliate.setFromDate(fromDate)
-        expect(affiliate.getFromDate()).toEqual(fromDate)
-    })
+  it('when you get the birth date from a affiliate that hasn´t an birth data it returns a null', () => {
+    affiliate.setBirthDate(null)
+    expect(affiliate.getBirthDate()).toBeNull()
+  })
+  it('when you get the nic issueDate date from a affiliate that hasn´t an nic Issue date data it returns a null', () => {
+    affiliate.setNicIssueDate(null)
+    expect(affiliate.getNicIssueDate()).toBeNull()
+  })
+  it('when you get the from Date date from a affiliate that hasn´t an from date data it returns a null', () => {
+    affiliate.setFromDate(null)
+    expect(affiliate.getFromDate()).toBeNull()
+  })
 
-    it('when you get the to date from a affiliate that has an  to date it returns a string representation', () => {
-        const toDate = '21/01/1998'
-        affiliate.setToDate(toDate)
-        expect(affiliate.getToDate()).toEqual(toDate)
-    })
-
-    it('when you get the birth date from a affiliate that hasn´t an birth data it returns a null', () => {
-        affiliate.setBirthDate(null)
-        expect(affiliate.getBirthDate()).toBeNull()
-    })
-    it('when you get the nic issueDate date from a affiliate that hasn´t an nic Issue date data it returns a null', () => {
-        affiliate.setNicIssueDate(null)
-        expect(affiliate.getNicIssueDate()).toBeNull()
-    })
-    it('when you get the from Date date from a affiliate that hasn´t an from date data it returns a null', () => {
-        affiliate.setFromDate(null)
-        expect(affiliate.getFromDate()).toBeNull()
-    })
-
-    it('when you get the to Date date from a affiliate that hasn´t an to date data it returns a null', () => {
-        affiliate.setToDate(null)
-        expect(affiliate.getToDate()).toBeNull()
-    })
-
-
+  it('when you get the to Date date from a affiliate that hasn´t an to date data it returns a null', () => {
+    affiliate.setToDate(null)
+    expect(affiliate.getToDate()).toBeNull()
+  })
 })

--- a/test/unit/dominio/doctor.spec.js
+++ b/test/unit/dominio/doctor.spec.js
@@ -17,155 +17,147 @@ const email = 'juan.anonimo@correo.com'
 const nationalMatriculation = 665544
 const provincialMatriculation = 887766
 
-const testDoctor = { id, name, lastName, userName, birthDate, entryDate, leavingDate, contactNumber, nationality, address, email, nationalMatriculation, provincialMatriculation }
+const testDoctor = {
+  id, name, lastName, userName, birthDate, entryDate, leavingDate, contactNumber, nationality, address, email, nationalMatriculation, provincialMatriculation,
+}
 
 describe('Doctor', () => {
-    let doctor = new Doctor()
+  let doctor = new Doctor()
 
-    beforeEach(() => {
-        doctor = new Doctor()
-    })
+  beforeEach(() => {
+    doctor = new Doctor()
+  })
 
-    it('has all this properties', () => {
-        expect(doctor).toHaveProperty('id')
-        expect(doctor).toHaveProperty('name')
-        expect(doctor).toHaveProperty('lastName')
-        expect(doctor).toHaveProperty('userName')
-        expect(doctor).toHaveProperty('birthDate')
-        expect(doctor).toHaveProperty('entryDate')
-        expect(doctor).toHaveProperty('leavingDate')
-        expect(doctor).toHaveProperty('contactNumber')
-        expect(doctor).toHaveProperty('nationality')
-        expect(doctor).toHaveProperty('address')
-        expect(doctor).toHaveProperty('email')
-        expect(doctor).toHaveProperty('nationalMatriculation')
-        expect(doctor).toHaveProperty('provincialMatriculation')
-    })
+  it('has all this properties', () => {
+    expect(doctor).toHaveProperty('id')
+    expect(doctor).toHaveProperty('name')
+    expect(doctor).toHaveProperty('lastName')
+    expect(doctor).toHaveProperty('userName')
+    expect(doctor).toHaveProperty('birthDate')
+    expect(doctor).toHaveProperty('entryDate')
+    expect(doctor).toHaveProperty('leavingDate')
+    expect(doctor).toHaveProperty('contactNumber')
+    expect(doctor).toHaveProperty('nationality')
+    expect(doctor).toHaveProperty('address')
+    expect(doctor).toHaveProperty('email')
+    expect(doctor).toHaveProperty('nationalMatriculation')
+    expect(doctor).toHaveProperty('provincialMatriculation')
+  })
 
-    it('has this properties default values', () => {
-        expect(doctor.id).toBeNull()
-        expect(doctor.name).toBeNull()
-        expect(doctor.lastName).toBeNull()
-        expect(doctor.userName).toBeNull()
-        expect(doctor.birthDate).toBeNull()
-        expect(doctor.entryDate).toBeNull()
-        expect(doctor.leavingDate).toBeNull()
-        expect(doctor.contactNumber).toBeNull()
-        expect(doctor.nationality).toBeNull()
-        expect(doctor.address).toBeNull()
-        expect(doctor.email).toBeNull()
-        expect(doctor.nationalMatriculation).toBeNull()
-        expect(doctor.provincialMatriculation).toBeNull()
+  it('has this properties default values', () => {
+    expect(doctor.id).toBeNull()
+    expect(doctor.name).toBeNull()
+    expect(doctor.lastName).toBeNull()
+    expect(doctor.userName).toBeNull()
+    expect(doctor.birthDate).toBeNull()
+    expect(doctor.entryDate).toBeNull()
+    expect(doctor.leavingDate).toBeNull()
+    expect(doctor.contactNumber).toBeNull()
+    expect(doctor.nationality).toBeNull()
+    expect(doctor.address).toBeNull()
+    expect(doctor.email).toBeNull()
+    expect(doctor.nationalMatriculation).toBeNull()
+    expect(doctor.provincialMatriculation).toBeNull()
+  })
 
+  it('can be transformed to json', () => {
+    expect(doctor.toJson()).toEqual('{"id":null,"name":null,"lastName":null,"userName":null,"birthDate":null,"entryDate":null,"leavingDate":null,"contactNumber":null,"nationality":null,"address":null,"email":null,"nationalMatriculation":null,"provincialMatriculation":null,"specialty":null}')
+  })
 
-    })
-
-    it('can be transformed to json', () => {
-        expect(doctor.toJson()).toEqual("{\"id\":null,\"name\":null,\"lastName\":null,\"userName\":null,\"birthDate\":null,\"entryDate\":null,\"leavingDate\":null,\"contactNumber\":null,\"nationality\":null,\"address\":null,\"email\":null,\"nationalMatriculation\":null,\"provincialMatriculation\":null,\"specialty\":null}")
-    })
-
-    it('can be obtained from json', () => {
-        doctor = Doctor.fromJson(JSON.stringify(testDoctor))
-        expect(doctor.id).toEqual(id)
-        expect(doctor.name).toEqual(name)
-        expect(doctor.lastName).toEqual(lastName)
-        expect(doctor.userName).toEqual(userName)
-        expect(doctor.getBirthDate()).toEqual(birthDate)
-        expect(doctor.getEntryDate()).toEqual(entryDate)
-        expect(doctor.getLeavingDate()).toEqual(leavingDate)
-        expect(doctor.contactNumber).toEqual(contactNumber)
-        expect(doctor.nationality).toEqual(nationality)
-        expect(doctor.address).toEqual(address)
-        expect(doctor.email).toEqual(email)
-        expect(doctor.nationalMatriculation).toEqual(nationalMatriculation)
-        expect(doctor.provincialMatriculation).toEqual(provincialMatriculation)
-
-    })
+  it('can be obtained from json', () => {
+    doctor = Doctor.fromJson(JSON.stringify(testDoctor))
+    expect(doctor.id).toEqual(id)
+    expect(doctor.name).toEqual(name)
+    expect(doctor.lastName).toEqual(lastName)
+    expect(doctor.userName).toEqual(userName)
+    expect(doctor.getBirthDate()).toEqual(birthDate)
+    expect(doctor.getEntryDate()).toEqual(entryDate)
+    expect(doctor.getLeavingDate()).toEqual(leavingDate)
+    expect(doctor.contactNumber).toEqual(contactNumber)
+    expect(doctor.nationality).toEqual(nationality)
+    expect(doctor.address).toEqual(address)
+    expect(doctor.email).toEqual(email)
+    expect(doctor.nationalMatriculation).toEqual(nationalMatriculation)
+    expect(doctor.provincialMatriculation).toEqual(provincialMatriculation)
+  })
 
 
+  // Testing atributtes of date =D
+  it('when you set a valid birth date to a doctor it stores it like a moment', () => {
+    const birthDate = '13/04/1993'
+    expect(doctor.birthDate).toBeNull()
+    doctor.setBirthDate(birthDate)
+    expect(moment.isMoment(doctor.birthDate)).toBeTruthy()
+    expect(doctor.birthDate.format(formats.dateFormat)).toEqual(birthDate)
+  })
 
-    // Testing atributtes of date =D
-    it('when you set a valid birth date to a doctor it stores it like a moment', () => {
-        const birthDate = '13/04/1993'
-        expect(doctor.birthDate).toBeNull()
-        doctor.setBirthDate(birthDate)
-        expect(moment.isMoment(doctor.birthDate)).toBeTruthy()
-        expect(doctor.birthDate.format(formats.dateFormat)).toEqual(birthDate)
-    })
+  it('when you set a valid entry date to a doctor it stores it like a moment', () => {
+    const entryDate = '01/01/1998'
+    expect(doctor.entryDate).toBeNull()
+    doctor.setEntryDate(entryDate)
+    expect(moment.isMoment(doctor.entryDate)).toBeTruthy()
+    expect(doctor.entryDate.format(formats.dateFormat)).toEqual(entryDate)
+  })
 
-    it('when you set a valid entry date to a doctor it stores it like a moment', () => {
-        const entryDate = '01/01/1998'
-        expect(doctor.entryDate).toBeNull()
-        doctor.setEntryDate(entryDate)
-        expect(moment.isMoment(doctor.entryDate)).toBeTruthy()
-        expect(doctor.entryDate.format(formats.dateFormat)).toEqual(entryDate)
-    })
-
-    it('when you set a valid leaving date to a doctor it stores it like a moment', () => {
-        const leavingDate = '01/01/1998'
-        expect(doctor.leavingDate).toBeNull()
-        doctor.setLeavingDate(leavingDate)
-        expect(moment.isMoment(doctor.leavingDate)).toBeTruthy()
-        expect(doctor.leavingDate.format(formats.dateFormat)).toEqual(leavingDate)
-    })
-
+  it('when you set a valid leaving date to a doctor it stores it like a moment', () => {
+    const leavingDate = '01/01/1998'
+    expect(doctor.leavingDate).toBeNull()
+    doctor.setLeavingDate(leavingDate)
+    expect(moment.isMoment(doctor.leavingDate)).toBeTruthy()
+    expect(doctor.leavingDate.format(formats.dateFormat)).toEqual(leavingDate)
+  })
 
 
-    it('when you set an invalid birth date to a doctor it stores a null', () => {
-        const birthDate = '40/02/1998'
-        expect(doctor.birthDate).toBeNull()
-        doctor.setBirthDate(birthDate)
-        expect(doctor.birthDate).toBeNull()
-    })
-    it('when you set an invalid entry date to a doctor it stores a null', () => {
-        const entryDate = '30/02/1998 23:00'
-        expect(doctor.entryDate).toBeNull()
-        doctor.setEntryDate(entryDate)
-        expect(doctor.entryDate).toBeNull()
-    })
+  it('when you set an invalid birth date to a doctor it stores a null', () => {
+    const birthDate = '40/02/1998'
+    expect(doctor.birthDate).toBeNull()
+    doctor.setBirthDate(birthDate)
+    expect(doctor.birthDate).toBeNull()
+  })
+  it('when you set an invalid entry date to a doctor it stores a null', () => {
+    const entryDate = '30/02/1998 23:00'
+    expect(doctor.entryDate).toBeNull()
+    doctor.setEntryDate(entryDate)
+    expect(doctor.entryDate).toBeNull()
+  })
 
-    it('when you set an invalid leaving date to a doctor it stores a null', () => {
-        const leavingDate = '30/02/1998 23:00'
-        expect(doctor.leavingDate).toBeNull()
-        doctor.setLeavingDate(leavingDate)
-        expect(doctor.leavingDate).toBeNull()
-    })
-
-
+  it('when you set an invalid leaving date to a doctor it stores a null', () => {
+    const leavingDate = '30/02/1998 23:00'
+    expect(doctor.leavingDate).toBeNull()
+    doctor.setLeavingDate(leavingDate)
+    expect(doctor.leavingDate).toBeNull()
+  })
 
 
-    it('when you get the birth date from a doctor that has an birth date it returns a string representation', () => {
-        const birthDate = '20/01/1998'
-        doctor.setBirthDate(birthDate)
-        expect(doctor.getBirthDate()).toEqual(birthDate)
-    })
-    it('when you get the entry date from a doctor that has an entry date it returns a string representation', () => {
-        const entryDate = '01/01/1998'
-        doctor.setEntryDate(entryDate)
-        expect(doctor.getEntryDate()).toEqual(entryDate)
-    })
+  it('when you get the birth date from a doctor that has an birth date it returns a string representation', () => {
+    const birthDate = '20/01/1998'
+    doctor.setBirthDate(birthDate)
+    expect(doctor.getBirthDate()).toEqual(birthDate)
+  })
+  it('when you get the entry date from a doctor that has an entry date it returns a string representation', () => {
+    const entryDate = '01/01/1998'
+    doctor.setEntryDate(entryDate)
+    expect(doctor.getEntryDate()).toEqual(entryDate)
+  })
 
-    it('when you get the leaving date from a doctor that has an leaving date it returns a string representation', () => {
-        const leavingDate = '09/02/1998'
-        doctor.setLeavingDate(leavingDate)
-        expect(doctor.getLeavingDate()).toEqual(leavingDate)
-    })
-
-
+  it('when you get the leaving date from a doctor that has an leaving date it returns a string representation', () => {
+    const leavingDate = '09/02/1998'
+    doctor.setLeavingDate(leavingDate)
+    expect(doctor.getLeavingDate()).toEqual(leavingDate)
+  })
 
 
-    it('when you get the birth date from a doctor that hasn´t an birth data it returns a null', () => {
-        doctor.setBirthDate(null)
-        expect(doctor.getBirthDate()).toBeNull()
-    })
+  it('when you get the birth date from a doctor that hasn´t an birth data it returns a null', () => {
+    doctor.setBirthDate(null)
+    expect(doctor.getBirthDate()).toBeNull()
+  })
 
-    it('when you get the entry date from a doctor that hasn´t an entry data it returns a null', () => {
-        doctor.setEntryDate(null)
-        expect(doctor.getEntryDate()).toBeNull()
-    })
-    it('when you get the leaving date from a doctor that hasn´t an leaving data it returns a null', () => {
-        doctor.setLeavingDate(null)
-        expect(doctor.getLeavingDate()).toBeNull()
-    })
-
+  it('when you get the entry date from a doctor that hasn´t an entry data it returns a null', () => {
+    doctor.setEntryDate(null)
+    expect(doctor.getEntryDate()).toBeNull()
+  })
+  it('when you get the leaving date from a doctor that hasn´t an leaving data it returns a null', () => {
+    doctor.setLeavingDate(null)
+    expect(doctor.getLeavingDate()).toBeNull()
+  })
 })

--- a/test/unit/dominio/institution.spec.js
+++ b/test/unit/dominio/institution.spec.js
@@ -8,34 +8,33 @@ const address = 'Av. Diego Carman 555'
 const testerInstitution = { id, description, address }
 
 describe('Institution', () => {
-    let institution = new Institution()
+  let institution = new Institution()
 
-    beforeEach(() => {
-        institution = new Institution()
-    })
+  beforeEach(() => {
+    institution = new Institution()
+  })
 
-    it('has all this properties', () => {
-        expect(institution).toHaveProperty('id')
-        expect(institution).toHaveProperty('description')
-        expect(institution).toHaveProperty('address')
-    })
+  it('has all this properties', () => {
+    expect(institution).toHaveProperty('id')
+    expect(institution).toHaveProperty('description')
+    expect(institution).toHaveProperty('address')
+  })
 
-    it('has this properties default values', () => {
-        expect(institution.id).toBeNull()
-        expect(institution.description).toBeNull()
-        expect(institution.address).toBeNull()
-    })
+  it('has this properties default values', () => {
+    expect(institution.id).toBeNull()
+    expect(institution.description).toBeNull()
+    expect(institution.address).toBeNull()
+  })
 
 
-    it('can be transformed to json', () => {
-        expect(institution.toJson()).toEqual("{\"id\":null,\"description\":null,\"address\":null}")
-    })
+  it('can be transformed to json', () => {
+    expect(institution.toJson()).toEqual('{"id":null,"description":null,"address":null}')
+  })
 
-    it('can be obtained from json', () => {
-        institution = Institution.fromJson(JSON.stringify(testerInstitution))
-        expect(institution.id).toEqual(id)
-        expect(institution.description).toEqual(description)
-        expect(institution.address).toEqual(address)
-    })
-
+  it('can be obtained from json', () => {
+    institution = Institution.fromJson(JSON.stringify(testerInstitution))
+    expect(institution.id).toEqual(id)
+    expect(institution.description).toEqual(description)
+    expect(institution.address).toEqual(address)
+  })
 })

--- a/test/unit/dominio/item.spec.js
+++ b/test/unit/dominio/item.spec.js
@@ -4,90 +4,90 @@ const moment = require('moment')
 
 const id = 1
 const prescribed = {
-    quantity: 10,
-    medicine: {
-        id: 11
-    }
+  quantity: 10,
+  medicine: {
+    id: 11,
+  },
 }
 const received = {
-    quantity: 10,
-    soldDate: '15/06/2019 20:00',
-    medicine: {
-        id: 11
-    },
-    pharmacist: {
-        id: 1
-    }
+  quantity: 10,
+  soldDate: '15/06/2019 20:00',
+  medicine: {
+    id: 11,
+  },
+  pharmacist: {
+    id: 1,
+  },
 }
 const audited = {
-    quantity: 99,
-    medicine: {
-        id: 11
-    }
+  quantity: 99,
+  medicine: {
+    id: 11,
+  },
 }
 
-const testItem = { id, prescribed, received, audited }
+const testItem = {
+  id, prescribed, received, audited,
+}
 
 describe('Item', () => {
-    let item = new Item()
+  let item = new Item()
 
-    beforeEach(() => {
-        item = new Item()
-    })
+  beforeEach(() => {
+    item = new Item()
+  })
 
-    it('has all this properties', () => {
-        expect(item).toHaveProperty('id')
-        expect(item).toHaveProperty('prescribed')
-        expect(item).toHaveProperty('prescribed.quantity')
-        expect(item).toHaveProperty('prescribed.medicine')
-        expect(item).toHaveProperty('received')
-        expect(item).toHaveProperty('received.quantity')
-        expect(item).toHaveProperty('received.medicine')
-        expect(item).toHaveProperty('received.soldDate')
-        expect(item).toHaveProperty('received.pharmacist')
-        expect(item).toHaveProperty('audited')
-        expect(item).toHaveProperty('audited.quantity')
-        expect(item).toHaveProperty('audited.medicine')
-    })
+  it('has all this properties', () => {
+    expect(item).toHaveProperty('id')
+    expect(item).toHaveProperty('prescribed')
+    expect(item).toHaveProperty('prescribed.quantity')
+    expect(item).toHaveProperty('prescribed.medicine')
+    expect(item).toHaveProperty('received')
+    expect(item).toHaveProperty('received.quantity')
+    expect(item).toHaveProperty('received.medicine')
+    expect(item).toHaveProperty('received.soldDate')
+    expect(item).toHaveProperty('received.pharmacist')
+    expect(item).toHaveProperty('audited')
+    expect(item).toHaveProperty('audited.quantity')
+    expect(item).toHaveProperty('audited.medicine')
+  })
 
-    it('has this properties default values', () => {
-        expect(item.id).toBeNull()
-        expect(item.prescribed.quantity).toBeNull()
-        expect(item.prescribed.medicine.id).toBeNull()
-        expect(item.received.quantity).toBeNull()
-        expect(item.received.medicine.id).toBeNull()
-        expect(item.received.soldDate).toBeNull()
-        expect(item.received.pharmacist.id).toBeNull()
-        expect(item.audited.quantity).toBeNull()
-        expect(item.audited.medicine.id).toBeNull()
+  it('has this properties default values', () => {
+    expect(item.id).toBeNull()
+    expect(item.prescribed.quantity).toBeNull()
+    expect(item.prescribed.medicine.id).toBeNull()
+    expect(item.received.quantity).toBeNull()
+    expect(item.received.medicine.id).toBeNull()
+    expect(item.received.soldDate).toBeNull()
+    expect(item.received.pharmacist.id).toBeNull()
+    expect(item.audited.quantity).toBeNull()
+    expect(item.audited.medicine.id).toBeNull()
+  })
+  it('can be transformed to json', () => {
+    expect(item.toJson()).toEqual('{"id":null,"prescribed":{"quantity":null,"medicine":{"id":null}},"received":{"quantity":null,"soldDate":null,"medicine":{"id":null},"pharmacist":{"id":null}},"audited":{"quantity":null,"medicine":{"id":null}}}')
+  })
+  it('can be obtained from json', () => {
+    item = Item.fromJson(JSON.stringify(testItem))
+    expect(item.id).toEqual(id)
+    expect(item.prescribed).toEqual(prescribed)
+    expect(item.received).toEqual({ ...received, soldDate: dateTimeFormat.toDate(received.soldDate) })
+    expect(item.audited).toEqual(audited)
+  })
 
-    })
-    it('can be transformed to json', () => {
-        expect(item.toJson()).toEqual("{\"id\":null,\"prescribed\":{\"quantity\":null,\"medicine\":{\"id\":null}},\"received\":{\"quantity\":null,\"soldDate\":null,\"medicine\":{\"id\":null},\"pharmacist\":{\"id\":null}},\"audited\":{\"quantity\":null,\"medicine\":{\"id\":null}}}")
-    })
-    it('can be obtained from json', () => {
-        item = Item.fromJson(JSON.stringify(testItem))
-        expect(item.id).toEqual(id)
-        expect(item.prescribed).toEqual(prescribed)
-        expect(item.received).toEqual({...received, soldDate: dateTimeFormat.toDate(received.soldDate)})
-        expect(item.audited).toEqual(audited)
-    })
+  it('can be obtained from an unknown object', () => {
+    item = Item.fromObject(testItem)
+    expect(item.id).toEqual(id)
+    expect(item.prescribed).toEqual(prescribed)
+    expect(item.received).toEqual({ ...received, soldDate: dateTimeFormat.toDate(received.soldDate) })
+    expect(item.audited).toEqual(audited)
+  })
 
-    it('can be obtained from an unknown object', () => {
-        item = Item.fromObject(testItem)
-        expect(item.id).toEqual(id)
-        expect(item.prescribed).toEqual(prescribed)
-        expect(item.received).toEqual({...received, soldDate: dateTimeFormat.toDate(received.soldDate)})
-        expect(item.audited).toEqual(audited)
-    })
-
-    it('when you prescribe item with quantity and medicine and is cool', () => {
-        let quantity = 20
-        let medicine = { id: 54 }
-        let testPrecribed = { quantity, medicine }
-        item.id = id
-        item.prescribe(quantity, medicine)
-        expect(item.prescribed).toEqual(testPrecribed)
-    })
-
+  it('when you prescribe item with quantity and medicine and is cool', () => {
+    const quantity = 20
+    const medicine = { id: 54 }
+    const testPrecribed = { quantity, medicine }
+    item.id = id
+    item.prescribe(quantity, medicine)
+    expect(item.prescribed).toEqual(testPrecribed)
+  })
 })

--- a/test/unit/dominio/medicalInsurance.spec.js
+++ b/test/unit/dominio/medicalInsurance.spec.js
@@ -8,49 +8,50 @@ const email = 'osde@medicalGroup.com'
 const address = 'Evergreen 742'
 const contactNumber = 5553226
 
-const testerMedicalInsurance = { id, description, userName, corporateName, email, address, contactNumber }
+const testerMedicalInsurance = {
+  id, description, userName, corporateName, email, address, contactNumber,
+}
 
 describe('MedicalInsurance', () => {
-    let medicalInsurance = new MedicalInsurance()
+  let medicalInsurance = new MedicalInsurance()
 
-    beforeEach(() => {
-        medicalInsurance = new MedicalInsurance()
-    })
+  beforeEach(() => {
+    medicalInsurance = new MedicalInsurance()
+  })
 
-    it('has all this properties', () => {
-        expect(medicalInsurance).toHaveProperty('id')
-        expect(medicalInsurance).toHaveProperty('description')
-        expect(medicalInsurance).toHaveProperty('userName')
-        expect(medicalInsurance).toHaveProperty('corporateName')
-        expect(medicalInsurance).toHaveProperty('email')
-        expect(medicalInsurance).toHaveProperty('address')
-        expect(medicalInsurance).toHaveProperty('contactNumber')
-    })
+  it('has all this properties', () => {
+    expect(medicalInsurance).toHaveProperty('id')
+    expect(medicalInsurance).toHaveProperty('description')
+    expect(medicalInsurance).toHaveProperty('userName')
+    expect(medicalInsurance).toHaveProperty('corporateName')
+    expect(medicalInsurance).toHaveProperty('email')
+    expect(medicalInsurance).toHaveProperty('address')
+    expect(medicalInsurance).toHaveProperty('contactNumber')
+  })
 
-    it('has this properties default values', () => {
-        expect(medicalInsurance.id).toBeNull()
-        expect(medicalInsurance.description).toBeNull()
-        expect(medicalInsurance.userName).toBeNull()
-        expect(medicalInsurance.corporateName).toBeNull()
-        expect(medicalInsurance.email).toBeNull()
-        expect(medicalInsurance.address).toBeNull()
-        expect(medicalInsurance.contactNumber).toBeNull()
-    })
+  it('has this properties default values', () => {
+    expect(medicalInsurance.id).toBeNull()
+    expect(medicalInsurance.description).toBeNull()
+    expect(medicalInsurance.userName).toBeNull()
+    expect(medicalInsurance.corporateName).toBeNull()
+    expect(medicalInsurance.email).toBeNull()
+    expect(medicalInsurance.address).toBeNull()
+    expect(medicalInsurance.contactNumber).toBeNull()
+  })
 
 
-    it('can be transformed to json', () => {
-        expect(medicalInsurance.toJson()).toEqual("{\"id\":null,\"description\":null,\"userName\":null,\"corporateName\":null,\"email\":null,\"address\":null,\"contactNumber\":null}")
-    })
+  it('can be transformed to json', () => {
+    expect(medicalInsurance.toJson()).toEqual('{"id":null,"description":null,"userName":null,"corporateName":null,"email":null,"address":null,"contactNumber":null}')
+  })
 
-    it('can be obtained from json', () => {
-        medicalInsurance = MedicalInsurance.fromJson(JSON.stringify(testerMedicalInsurance))
-        expect(medicalInsurance.id).toEqual(id)
-        expect(medicalInsurance.description).toEqual(description)
-        expect(medicalInsurance.userName).toEqual(userName)
-        expect(medicalInsurance.corporateName).toEqual(corporateName)
-        expect(medicalInsurance.email).toEqual(email)
-        expect(medicalInsurance.address).toEqual(address)
-        expect(medicalInsurance.contactNumber).toEqual(contactNumber)
-    })
-
+  it('can be obtained from json', () => {
+    medicalInsurance = MedicalInsurance.fromJson(JSON.stringify(testerMedicalInsurance))
+    expect(medicalInsurance.id).toEqual(id)
+    expect(medicalInsurance.description).toEqual(description)
+    expect(medicalInsurance.userName).toEqual(userName)
+    expect(medicalInsurance.corporateName).toEqual(corporateName)
+    expect(medicalInsurance.email).toEqual(email)
+    expect(medicalInsurance.address).toEqual(address)
+    expect(medicalInsurance.contactNumber).toEqual(contactNumber)
+  })
 })

--- a/test/unit/dominio/medicine.spec.js
+++ b/test/unit/dominio/medicine.spec.js
@@ -17,120 +17,117 @@ const laboratoryDescription = 'PFIZER'
 const potencyDescription = 400
 
 const testerMedicine = {
-    id, description, troquel, pharmaceuticalAction, entryDate, leavingDate, barCode, brandDescription, sizeDescription, presentationDescription, drugDescription, laboratoryDescription, potencyDescription
+  id, description, troquel, pharmaceuticalAction, entryDate, leavingDate, barCode, brandDescription, sizeDescription, presentationDescription, drugDescription, laboratoryDescription, potencyDescription,
 }
 
 describe('Medicine', () => {
-    let medicine = new Medicine()
+  let medicine = new Medicine()
 
-    beforeEach(() => {
-        medicine = new Medicine()
-    })
+  beforeEach(() => {
+    medicine = new Medicine()
+  })
 
-    it('has all this properties', () => {
-        expect(medicine).toHaveProperty('id')
-        expect(medicine).toHaveProperty('description')
-        expect(medicine).toHaveProperty('troquel')
-        expect(medicine).toHaveProperty('pharmaceuticalAction')
-        expect(medicine).toHaveProperty('entryDate')
-        expect(medicine).toHaveProperty('leavingDate')
-        expect(medicine).toHaveProperty('barCode')
-        expect(medicine).toHaveProperty('brandDescription')
-        expect(medicine).toHaveProperty('sizeDescription')
-        expect(medicine).toHaveProperty('presentationDescription')
-        expect(medicine).toHaveProperty('drugDescription')
-        expect(medicine).toHaveProperty('laboratoryDescription')
-        expect(medicine).toHaveProperty('potencyDescription')
-    })
+  it('has all this properties', () => {
+    expect(medicine).toHaveProperty('id')
+    expect(medicine).toHaveProperty('description')
+    expect(medicine).toHaveProperty('troquel')
+    expect(medicine).toHaveProperty('pharmaceuticalAction')
+    expect(medicine).toHaveProperty('entryDate')
+    expect(medicine).toHaveProperty('leavingDate')
+    expect(medicine).toHaveProperty('barCode')
+    expect(medicine).toHaveProperty('brandDescription')
+    expect(medicine).toHaveProperty('sizeDescription')
+    expect(medicine).toHaveProperty('presentationDescription')
+    expect(medicine).toHaveProperty('drugDescription')
+    expect(medicine).toHaveProperty('laboratoryDescription')
+    expect(medicine).toHaveProperty('potencyDescription')
+  })
 
-    it('has this properties default values', () => {
-        expect(medicine.id).toBeNull()
-        expect(medicine.description).toBeNull()
-        expect(medicine.troquel).toBeNull()
-        expect(medicine.pharmaceuticalAction).toBeNull()
-        expect(medicine.getEntryDate()).toBeNull()
-        expect(medicine.getLeavingDate()).toBeNull()
-        expect(medicine.barCode).toBeNull()
-        expect(medicine.brandDescription).toBeNull()
-        expect(medicine.sizeDescription).toBeNull()
-        expect(medicine.presentationDescription).toBeNull()
-        expect(medicine.drugDescription).toBeNull()
-        expect(medicine.laboratoryDescription).toBeNull()
-        expect(medicine.potencyDescription).toBeNull()
+  it('has this properties default values', () => {
+    expect(medicine.id).toBeNull()
+    expect(medicine.description).toBeNull()
+    expect(medicine.troquel).toBeNull()
+    expect(medicine.pharmaceuticalAction).toBeNull()
+    expect(medicine.getEntryDate()).toBeNull()
+    expect(medicine.getLeavingDate()).toBeNull()
+    expect(medicine.barCode).toBeNull()
+    expect(medicine.brandDescription).toBeNull()
+    expect(medicine.sizeDescription).toBeNull()
+    expect(medicine.presentationDescription).toBeNull()
+    expect(medicine.drugDescription).toBeNull()
+    expect(medicine.laboratoryDescription).toBeNull()
+    expect(medicine.potencyDescription).toBeNull()
+  })
 
-    })
+  it('can be transformed to json', () => {
+    expect(medicine.toJson()).toEqual('{"id":null,"description":null,"troquel":null,"pharmaceuticalAction":null,"entryDate":null,"leavingDate":null,"barCode":null,"brandDescription":null,"sizeDescription":null,"presentationDescription":null,"drugDescription":null,"laboratoryDescription":null,"potencyDescription":null}')
+  })
 
-    it('can be transformed to json', () => {
-        expect(medicine.toJson()).toEqual("{\"id\":null,\"description\":null,\"troquel\":null,\"pharmaceuticalAction\":null,\"entryDate\":null,\"leavingDate\":null,\"barCode\":null,\"brandDescription\":null,\"sizeDescription\":null,\"presentationDescription\":null,\"drugDescription\":null,\"laboratoryDescription\":null,\"potencyDescription\":null}")
-    })
+  it('can be obtained from json', () => {
+    medicine = Medicine.fromJson(JSON.stringify(testerMedicine))
+    expect(medicine.id).toEqual(id)
+    expect(medicine.description).toEqual(description)
+    expect(medicine.troquel).toEqual(troquel)
+    expect(medicine.pharmaceuticalAction).toEqual(pharmaceuticalAction)
+    expect(medicine.getEntryDate()).toEqual(entryDate)
+    expect(medicine.getLeavingDate()).toEqual(leavingDate)
+    expect(medicine.barCode).toEqual(barCode)
+    expect(medicine.brandDescription).toEqual(brandDescription)
+    expect(medicine.sizeDescription).toEqual(sizeDescription)
+    expect(medicine.presentationDescription).toEqual(presentationDescription)
+    expect(medicine.drugDescription).toEqual(drugDescription)
+    expect(medicine.laboratoryDescription).toEqual(laboratoryDescription)
+    expect(medicine.potencyDescription).toEqual(potencyDescription)
+  })
 
-    it('can be obtained from json', () => {
-        medicine = Medicine.fromJson(JSON.stringify(testerMedicine))
-        expect(medicine.id).toEqual(id)
-        expect(medicine.description).toEqual(description)
-        expect(medicine.troquel).toEqual(troquel)
-        expect(medicine.pharmaceuticalAction).toEqual(pharmaceuticalAction)
-        expect(medicine.getEntryDate()).toEqual(entryDate)
-        expect(medicine.getLeavingDate()).toEqual(leavingDate)
-        expect(medicine.barCode).toEqual(barCode)
-        expect(medicine.brandDescription).toEqual(brandDescription)
-        expect(medicine.sizeDescription).toEqual(sizeDescription)
-        expect(medicine.presentationDescription).toEqual(presentationDescription)
-        expect(medicine.drugDescription).toEqual(drugDescription)
-        expect(medicine.laboratoryDescription).toEqual(laboratoryDescription)
-        expect(medicine.potencyDescription).toEqual(potencyDescription)
-    })
+  it('when you set a valid entry date to a medicine it stores it like a moment', () => {
+    const entryDate = '01/01/1998'
+    expect(medicine.entryDate).toBeNull()
+    medicine.setEntryDate(entryDate)
+    expect(moment.isMoment(medicine.entryDate)).toBeTruthy()
+    expect(medicine.entryDate.format(formats.dateFormat)).toEqual(entryDate)
+  })
 
-    it('when you set a valid entry date to a medicine it stores it like a moment', () => {
-        const entryDate = '01/01/1998'
-        expect(medicine.entryDate).toBeNull()
-        medicine.setEntryDate(entryDate)
-        expect(moment.isMoment(medicine.entryDate)).toBeTruthy()
-        expect(medicine.entryDate.format(formats.dateFormat)).toEqual(entryDate)
-    })
+  it('when you set a valid leaving date to a medicine it stores it like a moment', () => {
+    const leavingDate = '01/01/1998'
+    expect(medicine.leavingDate).toBeNull()
+    medicine.setLeavingDate(leavingDate)
+    expect(moment.isMoment(medicine.leavingDate)).toBeTruthy()
+    expect(medicine.leavingDate.format(formats.dateFormat)).toEqual(leavingDate)
+  })
 
-    it('when you set a valid leaving date to a medicine it stores it like a moment', () => {
-        const leavingDate = '01/01/1998'
-        expect(medicine.leavingDate).toBeNull()
-        medicine.setLeavingDate(leavingDate)
-        expect(moment.isMoment(medicine.leavingDate)).toBeTruthy()
-        expect(medicine.leavingDate.format(formats.dateFormat)).toEqual(leavingDate)
-    })
+  it('when you set an invalid entry date to a medicine it stores a null', () => {
+    const entryDate = '30/02/1998 23:00'
+    expect(medicine.entryDate).toBeNull()
+    medicine.setEntryDate(entryDate)
+    expect(medicine.entryDate).toBeNull()
+  })
 
-    it('when you set an invalid entry date to a medicine it stores a null', () => {
-        const entryDate = '30/02/1998 23:00'
-        expect(medicine.entryDate).toBeNull()
-        medicine.setEntryDate(entryDate)
-        expect(medicine.entryDate).toBeNull()
-    })
+  it('when you set an invalid leaving date to a medicine it stores a null', () => {
+    const leavingDate = '30/02/1998 23:00'
+    expect(medicine.leavingDate).toBeNull()
+    medicine.setLeavingDate(leavingDate)
+    expect(medicine.leavingDate).toBeNull()
+  })
 
-    it('when you set an invalid leaving date to a medicine it stores a null', () => {
-        const leavingDate = '30/02/1998 23:00'
-        expect(medicine.leavingDate).toBeNull()
-        medicine.setLeavingDate(leavingDate)
-        expect(medicine.leavingDate).toBeNull()
-    })
+  it('when you get the entry date from a medicine that has an entry date it returns a string representation', () => {
+    const entryDate = '01/01/1998'
+    medicine.setEntryDate(entryDate)
+    expect(medicine.getEntryDate()).toEqual(entryDate)
+  })
 
-    it('when you get the entry date from a medicine that has an entry date it returns a string representation', () => {
-        const entryDate = '01/01/1998'
-        medicine.setEntryDate(entryDate)
-        expect(medicine.getEntryDate()).toEqual(entryDate)
-    })
+  it('when you get the leaving date from a medicine that has an leaving date it returns a string representation', () => {
+    const leavingDate = '09/02/1998'
+    medicine.setLeavingDate(leavingDate)
+    expect(medicine.getLeavingDate()).toEqual(leavingDate)
+  })
 
-    it('when you get the leaving date from a medicine that has an leaving date it returns a string representation', () => {
-        const leavingDate = '09/02/1998'
-        medicine.setLeavingDate(leavingDate)
-        expect(medicine.getLeavingDate()).toEqual(leavingDate)
-    })
-
-    it('when you get the entry date from a medicine that hasn´t an entry data it returns a null', () => {
-        medicine.setEntryDate(null)
-        expect(medicine.getEntryDate()).toBeNull()
-    })
-    it('when you get the leaving date from a medicine that hasn´t an leaving data it returns a null', () => {
-        medicine.setLeavingDate(null)
-        expect(medicine.getLeavingDate()).toBeNull()
-    })
-
-
+  it('when you get the entry date from a medicine that hasn´t an entry data it returns a null', () => {
+    medicine.setEntryDate(null)
+    expect(medicine.getEntryDate()).toBeNull()
+  })
+  it('when you get the leaving date from a medicine that hasn´t an leaving data it returns a null', () => {
+    medicine.setLeavingDate(null)
+    expect(medicine.getLeavingDate()).toBeNull()
+  })
 })

--- a/test/unit/dominio/plan.spec.js
+++ b/test/unit/dominio/plan.spec.js
@@ -9,101 +9,100 @@ const leavingDate = '30/11/2027'
 const percentage = 20
 const idMedicalInsurance = 4
 
-const testPlan = { id, description, entryDate, leavingDate, percentage, idMedicalInsurance }
+const testPlan = {
+  id, description, entryDate, leavingDate, percentage, idMedicalInsurance,
+}
 
 describe('Plan', () => {
-    let plan = new Plan()
+  let plan = new Plan()
 
-    beforeEach(() => {
-        plan = new Plan()
-    })
+  beforeEach(() => {
+    plan = new Plan()
+  })
 
-    it('has all this properties', () => {
-        expect(plan).toHaveProperty('id')
-        expect(plan).toHaveProperty('entryDate')
-        expect(plan).toHaveProperty('leavingDate')
-        expect(plan).toHaveProperty('percentage')
-        expect(plan).toHaveProperty('idMedicalInsurance')
-    })
+  it('has all this properties', () => {
+    expect(plan).toHaveProperty('id')
+    expect(plan).toHaveProperty('entryDate')
+    expect(plan).toHaveProperty('leavingDate')
+    expect(plan).toHaveProperty('percentage')
+    expect(plan).toHaveProperty('idMedicalInsurance')
+  })
 
-    it('has this properties default values', () => {
-        expect(plan.id).toBeNull()
-        expect(plan.description).toBeNull()
-        expect(plan.getEntryDate()).toBeNull()
-        expect(plan.getLeavingDate()).toBeNull()
-        expect(plan.percentage).toBeNull()
-        expect(plan.idMedicalInsurance).toBeNull()
-    })
+  it('has this properties default values', () => {
+    expect(plan.id).toBeNull()
+    expect(plan.description).toBeNull()
+    expect(plan.getEntryDate()).toBeNull()
+    expect(plan.getLeavingDate()).toBeNull()
+    expect(plan.percentage).toBeNull()
+    expect(plan.idMedicalInsurance).toBeNull()
+  })
 
-    it('can be transformed to json', () => {
-        expect(plan.toJson()).toEqual("{\"id\":null,\"description\":null,\"entryDate\":null,\"leavingDate\":null,\"percentage\":null,\"idMedicalInsurance\":null}")
-    })
-
-
-    it('can be obtained from json', () => {
-        plan = Plan.fromJson(JSON.stringify(testPlan))
-        expect(plan.id).toEqual(id)
-        expect(plan.description).toEqual(description)
-        expect(plan.getEntryDate()).toEqual(entryDate)
-        expect(plan.getLeavingDate()).toEqual(leavingDate)
-        expect(plan.percentage).toEqual(percentage)
-        expect(plan.idMedicalInsurance).toEqual(idMedicalInsurance)
-    })
+  it('can be transformed to json', () => {
+    expect(plan.toJson()).toEqual('{"id":null,"description":null,"entryDate":null,"leavingDate":null,"percentage":null,"idMedicalInsurance":null}')
+  })
 
 
-    it('when you set a valid entry date to a plan it stores it like a moment', () => {
-        const entryDate = '19/10/2021'
-        expect(plan.entryDate).toBeNull()
-        plan.setEntryDate(entryDate)
-        expect(moment.isMoment(plan.entryDate)).toBeTruthy()
-        expect(plan.entryDate.format(formats.dateFormat)).toEqual(entryDate)
-    })
-
-    it('when you set a valid leaving date to a plan it stores it like a moment', () => {
-        const leavingDate = '09/09/1999'
-        expect(plan.leavingDate).toBeNull()
-        plan.setLeavingDate(leavingDate)
-        expect(moment.isMoment(plan.leavingDate)).toBeTruthy()
-        expect(plan.leavingDate.format(formats.dateFormat)).toEqual(leavingDate)
-    })
+  it('can be obtained from json', () => {
+    plan = Plan.fromJson(JSON.stringify(testPlan))
+    expect(plan.id).toEqual(id)
+    expect(plan.description).toEqual(description)
+    expect(plan.getEntryDate()).toEqual(entryDate)
+    expect(plan.getLeavingDate()).toEqual(leavingDate)
+    expect(plan.percentage).toEqual(percentage)
+    expect(plan.idMedicalInsurance).toEqual(idMedicalInsurance)
+  })
 
 
+  it('when you set a valid entry date to a plan it stores it like a moment', () => {
+    const entryDate = '19/10/2021'
+    expect(plan.entryDate).toBeNull()
+    plan.setEntryDate(entryDate)
+    expect(moment.isMoment(plan.entryDate)).toBeTruthy()
+    expect(plan.entryDate.format(formats.dateFormat)).toEqual(entryDate)
+  })
 
-    it('when you set an invalid entry date to a plan it stores a null', () => {
-        const entryDate = '30/02/1379 23:00'
-        expect(plan.entryDate).toBeNull()
-        plan.setEntryDate(entryDate)
-        expect(plan.entryDate).toBeNull()
-    })
-
-    it('when you set an invalid leaving date to a plan it stores a null', () => {
-        const leavingDate = '30/40/1794 23:00'
-        expect(plan.leavingDate).toBeNull()
-        plan.setLeavingDate(leavingDate)
-        expect(plan.leavingDate).toBeNull()
-    })
-
-    it('when you get the entry date from a plan that has an entry date it returns a string representation', () => {
-        const entryDate = '22/12/2022'
-        plan.setEntryDate(entryDate)
-        expect(plan.getEntryDate()).toEqual(entryDate)
-    })
-
-    it('when you get the leaving date from a plan that has an leaving date it returns a string representation', () => {
-        const leavingDate = '08/09/2023'
-        plan.setLeavingDate(leavingDate)
-        expect(plan.getLeavingDate()).toEqual(leavingDate)
-    })
+  it('when you set a valid leaving date to a plan it stores it like a moment', () => {
+    const leavingDate = '09/09/1999'
+    expect(plan.leavingDate).toBeNull()
+    plan.setLeavingDate(leavingDate)
+    expect(moment.isMoment(plan.leavingDate)).toBeTruthy()
+    expect(plan.leavingDate.format(formats.dateFormat)).toEqual(leavingDate)
+  })
 
 
-    it('when you get the entry date from a plan that hasn´t an entry data it returns a null', () => {
-        plan.setEntryDate(null)
-        expect(plan.getEntryDate()).toBeNull()
-    })
-    it('when you get the leaving date from a plan that hasn´t an leaving data it returns a null', () => {
-        plan.setLeavingDate(null)
-        expect(plan.getLeavingDate()).toBeNull()
-    })
+  it('when you set an invalid entry date to a plan it stores a null', () => {
+    const entryDate = '30/02/1379 23:00'
+    expect(plan.entryDate).toBeNull()
+    plan.setEntryDate(entryDate)
+    expect(plan.entryDate).toBeNull()
+  })
+
+  it('when you set an invalid leaving date to a plan it stores a null', () => {
+    const leavingDate = '30/40/1794 23:00'
+    expect(plan.leavingDate).toBeNull()
+    plan.setLeavingDate(leavingDate)
+    expect(plan.leavingDate).toBeNull()
+  })
+
+  it('when you get the entry date from a plan that has an entry date it returns a string representation', () => {
+    const entryDate = '22/12/2022'
+    plan.setEntryDate(entryDate)
+    expect(plan.getEntryDate()).toEqual(entryDate)
+  })
+
+  it('when you get the leaving date from a plan that has an leaving date it returns a string representation', () => {
+    const leavingDate = '08/09/2023'
+    plan.setLeavingDate(leavingDate)
+    expect(plan.getLeavingDate()).toEqual(leavingDate)
+  })
 
 
+  it('when you get the entry date from a plan that hasn´t an entry data it returns a null', () => {
+    plan.setEntryDate(null)
+    expect(plan.getEntryDate()).toBeNull()
+  })
+  it('when you get the leaving date from a plan that hasn´t an leaving data it returns a null', () => {
+    plan.setLeavingDate(null)
+    expect(plan.getLeavingDate()).toBeNull()
+  })
 })

--- a/test/unit/dominio/prescription.spec.js
+++ b/test/unit/dominio/prescription.spec.js
@@ -1,12 +1,12 @@
-const {Prescription} = require('../../../src/domain/prescription')
-const {Item} = require('../../../src/domain/item')
-const {formats} = require('../../../src/utils/utils')
+const { Prescription } = require('../../../src/domain/prescription')
+const { Item } = require('../../../src/domain/item')
+const { formats } = require('../../../src/utils/utils')
 const moment = require('moment')
-const {Affiliate} = require('../../../src/domain/affiliate')
-const {Doctor} = require('../../../src/domain/doctor')
-const {MedicalInsurance} = require('../../../src/domain/medicalInsurance')
-const {Institution} = require('../../../src/domain/institution')
-const {states} = require('../../../src/state-machine/state')
+const { Affiliate } = require('../../../src/domain/affiliate')
+const { Doctor } = require('../../../src/domain/doctor')
+const { MedicalInsurance } = require('../../../src/domain/medicalInsurance')
+const { Institution } = require('../../../src/domain/institution')
+const { states } = require('../../../src/state-machine/state')
 
 const affiliate = new Affiliate()
 affiliate.id = 12
@@ -26,175 +26,177 @@ const medicalInsurance = new MedicalInsurance()
 medicalInsurance.id = 44
 const norm = 1
 const prolongedTreatment = true
-const status = states.ISSUED.status
+const { status } = states.ISSUED
 const ttl = 12
-const testPrescription = {affiliate, doctor, auditedDate, diagnosis, id, institution, issuedDate, items, medicalInsurance, norm, prolongedTreatment, soldDate, status, ttl}
+const testPrescription = {
+  affiliate, doctor, auditedDate, diagnosis, id, institution, issuedDate, items, medicalInsurance, norm, prolongedTreatment, soldDate, status, ttl,
+}
 
 describe('Prescription', () => {
-    let prescription = new Prescription()
+  let prescription = new Prescription()
 
-    beforeEach(() => {
-        prescription = new Prescription()
-    })
+  beforeEach(() => {
+    prescription = new Prescription()
+  })
 
-    it('has all this properties', () => {
-        expect(prescription).toHaveProperty('id')
-        expect(prescription).toHaveProperty('issuedDate')
-        expect(prescription).toHaveProperty('soldDate')
-        expect(prescription).toHaveProperty('auditedDate')
-        expect(prescription).toHaveProperty('prolongedTreatment')
-        expect(prescription).toHaveProperty('diagnosis')
-        expect(prescription).toHaveProperty('ttl')
-        expect(prescription).toHaveProperty('institution')
-        expect(prescription).toHaveProperty('affiliate')
-        expect(prescription).toHaveProperty('doctor')
-        expect(prescription).toHaveProperty('medicalInsurance')
-        expect(prescription).toHaveProperty('status')
-        expect(prescription).toHaveProperty('norm')
-        expect(prescription).toHaveProperty('items')
-    })
+  it('has all this properties', () => {
+    expect(prescription).toHaveProperty('id')
+    expect(prescription).toHaveProperty('issuedDate')
+    expect(prescription).toHaveProperty('soldDate')
+    expect(prescription).toHaveProperty('auditedDate')
+    expect(prescription).toHaveProperty('prolongedTreatment')
+    expect(prescription).toHaveProperty('diagnosis')
+    expect(prescription).toHaveProperty('ttl')
+    expect(prescription).toHaveProperty('institution')
+    expect(prescription).toHaveProperty('affiliate')
+    expect(prescription).toHaveProperty('doctor')
+    expect(prescription).toHaveProperty('medicalInsurance')
+    expect(prescription).toHaveProperty('status')
+    expect(prescription).toHaveProperty('norm')
+    expect(prescription).toHaveProperty('items')
+  })
 
-    it('has this properties default values', () => {
-        expect(prescription.id).toBeNull()
-        expect(prescription.issuedDate).toBeNull()
-        expect(prescription.soldDate).toBeNull()
-        expect(prescription.auditedDate).toBeNull()
-        expect(prescription.prolongedTreatment).toBeFalsy()
-        expect(prescription.diagnosis).toBeNull() 
-        expect(prescription.ttl).toBeNull()
-        expect(prescription.institution).toBeNull()
-        expect(prescription.affiliate).toBeNull()
-        expect(prescription.doctor).toBeNull()
-        expect(prescription.medicalInsurance).toBeNull()
-        expect(prescription.status).toBeNull()
-        expect(prescription.norm).toBeNull()
-        expect(prescription.items).toEqual([])
-    })
+  it('has this properties default values', () => {
+    expect(prescription.id).toBeNull()
+    expect(prescription.issuedDate).toBeNull()
+    expect(prescription.soldDate).toBeNull()
+    expect(prescription.auditedDate).toBeNull()
+    expect(prescription.prolongedTreatment).toBeFalsy()
+    expect(prescription.diagnosis).toBeNull()
+    expect(prescription.ttl).toBeNull()
+    expect(prescription.institution).toBeNull()
+    expect(prescription.affiliate).toBeNull()
+    expect(prescription.doctor).toBeNull()
+    expect(prescription.medicalInsurance).toBeNull()
+    expect(prescription.status).toBeNull()
+    expect(prescription.norm).toBeNull()
+    expect(prescription.items).toEqual([])
+  })
 
-    it('can add item to prescription', () => {
-        const item = new Item()
-        prescription.addItem(item)
-        expect(prescription.items).toContain(item)
-    })
+  it('can add item to prescription', () => {
+    const item = new Item()
+    prescription.addItem(item)
+    expect(prescription.items).toContain(item)
+  })
 
-    it('can be transformed to json', () => {
-        expect(prescription.toJson()).toEqual("{\"id\":null,\"issuedDate\":null,\"soldDate\":null,\"auditedDate\":null,\"prolongedTreatment\":false,\"diagnosis\":null,\"ttl\":null,\"institution\":null,\"affiliate\":null,\"doctor\":null,\"medicalInsurance\":null,\"status\":null,\"norm\":null,\"items\":[]}")
-        expect(Prescription.fromJson(testPrescription).toJson()).toEqual("{\"id\":1,\"issuedDate\":\"01/01/1992 12:45\",\"soldDate\":\"02/01/1992 12:45\",\"auditedDate\":\"03/01/1992 12:45\",\"prolongedTreatment\":true,\"diagnosis\":\"asdf\",\"ttl\":12,\"institution\":{\"id\":13,\"description\":null,\"address\":null},\"affiliate\":{\"id\":12,\"idPatient\":null,\"name\":null,\"surname\":null,\"userName\":null,\"birthDate\":null,\"gender\":null,\"contactNumber\":null,\"email\":null,\"address\":null,\"nationality\":null,\"nicNumber\":null,\"nicIssueDate\":null,\"nicType\":null,\"nicExemplary\":null,\"nicPhoto\":null,\"fromDate\":null,\"toDate\":null,\"code\":null,\"category\":null,\"imageCredential\":null,\"plan\":{\"id\":null,\"description\":null,\"entryDate\":null,\"leavingDate\":null,\"percentage\":null,\"idMedicalInsurance\":null}},\"doctor\":{\"id\":23,\"name\":null,\"lastName\":null,\"userName\":null,\"birthDate\":null,\"entryDate\":null,\"leavingDate\":null,\"contactNumber\":null,\"nationality\":null,\"address\":null,\"email\":null,\"nationalMatriculation\":null,\"provincialMatriculation\":null,\"specialty\":null},\"medicalInsurance\":{\"id\":44,\"description\":null,\"userName\":null,\"corporateName\":null,\"email\":null,\"address\":null,\"contactNumber\":null},\"status\":\"EMITIDA\",\"norm\":1,\"items\":[{\"id\":13,\"prescribed\":{\"quantity\":null,\"medicine\":{\"id\":null}},\"received\":{\"quantity\":null,\"soldDate\":null,\"medicine\":{\"id\":null},\"pharmacist\":{\"id\":null}},\"audited\":{\"quantity\":null,\"medicine\":{\"id\":null}}}]}")
-    })
+  it('can be transformed to json', () => {
+    expect(prescription.toJson()).toEqual('{"id":null,"issuedDate":null,"soldDate":null,"auditedDate":null,"prolongedTreatment":false,"diagnosis":null,"ttl":null,"institution":null,"affiliate":null,"doctor":null,"medicalInsurance":null,"status":null,"norm":null,"items":[]}')
+    expect(Prescription.fromJson(testPrescription).toJson()).toEqual('{"id":1,"issuedDate":"01/01/1992 12:45","soldDate":"02/01/1992 12:45","auditedDate":"03/01/1992 12:45","prolongedTreatment":true,"diagnosis":"asdf","ttl":12,"institution":{"id":13,"description":null,"address":null},"affiliate":{"id":12,"idPatient":null,"name":null,"surname":null,"userName":null,"birthDate":null,"gender":null,"contactNumber":null,"email":null,"address":null,"nationality":null,"nicNumber":null,"nicIssueDate":null,"nicType":null,"nicExemplary":null,"nicPhoto":null,"fromDate":null,"toDate":null,"code":null,"category":null,"imageCredential":null,"plan":{"id":null,"description":null,"entryDate":null,"leavingDate":null,"percentage":null,"idMedicalInsurance":null}},"doctor":{"id":23,"name":null,"lastName":null,"userName":null,"birthDate":null,"entryDate":null,"leavingDate":null,"contactNumber":null,"nationality":null,"address":null,"email":null,"nationalMatriculation":null,"provincialMatriculation":null,"specialty":null},"medicalInsurance":{"id":44,"description":null,"userName":null,"corporateName":null,"email":null,"address":null,"contactNumber":null},"status":"EMITIDA","norm":1,"items":[{"id":13,"prescribed":{"quantity":null,"medicine":{"id":null}},"received":{"quantity":null,"soldDate":null,"medicine":{"id":null},"pharmacist":{"id":null}},"audited":{"quantity":null,"medicine":{"id":null}}}]}')
+  })
 
-    it('can be obtained from json', () => {
-        prescription = Prescription.fromJson(JSON.stringify(testPrescription))
-        expect(prescription.id).toEqual(id)
-        expect(prescription.getIssuedDate()).toEqual(issuedDate)
-        expect(prescription.getSoldDate()).toEqual(soldDate)
-        expect(prescription.getAuditedDate()).toEqual(auditedDate)
-        expect(prescription.prolongedTreatment).toEqual(prolongedTreatment)
-        expect(prescription.diagnosis).toEqual(diagnosis)
-        expect(prescription.ttl).toEqual(ttl)
-        expect(prescription.institution).toEqual(institution)
-        expect(prescription.affiliate).toEqual(affiliate)
-        expect(prescription.doctor).toEqual(doctor)
-        expect(prescription.medicalInsurance).toEqual(medicalInsurance)
-        expect(prescription.status).toEqual(status)
-        expect(prescription.norm).toEqual(norm)
-        expect(prescription.items).toEqual(items)
-    })
+  it('can be obtained from json', () => {
+    prescription = Prescription.fromJson(JSON.stringify(testPrescription))
+    expect(prescription.id).toEqual(id)
+    expect(prescription.getIssuedDate()).toEqual(issuedDate)
+    expect(prescription.getSoldDate()).toEqual(soldDate)
+    expect(prescription.getAuditedDate()).toEqual(auditedDate)
+    expect(prescription.prolongedTreatment).toEqual(prolongedTreatment)
+    expect(prescription.diagnosis).toEqual(diagnosis)
+    expect(prescription.ttl).toEqual(ttl)
+    expect(prescription.institution).toEqual(institution)
+    expect(prescription.affiliate).toEqual(affiliate)
+    expect(prescription.doctor).toEqual(doctor)
+    expect(prescription.medicalInsurance).toEqual(medicalInsurance)
+    expect(prescription.status).toEqual(status)
+    expect(prescription.norm).toEqual(norm)
+    expect(prescription.items).toEqual(items)
+  })
 
-    it('can be obtained from an unknown object', () => {
-        prescription = Prescription.fromObject(testPrescription)
-        expect(prescription.id).toEqual(id)
-        expect(prescription.getIssuedDate()).toEqual(issuedDate)
-        expect(prescription.getSoldDate()).toEqual(soldDate)
-        expect(prescription.getAuditedDate()).toEqual(auditedDate)
-        expect(prescription.prolongedTreatment).toEqual(prolongedTreatment)
-        expect(prescription.diagnosis).toEqual(diagnosis)
-        expect(prescription.ttl).toEqual(ttl)
-        expect(prescription.institution).toEqual(institution)
-        expect(prescription.affiliate).toEqual(affiliate)
-        expect(prescription.doctor).toEqual(doctor)
-        expect(prescription.medicalInsurance).toEqual(medicalInsurance)
-        expect(prescription.status).toEqual(status)
-        expect(prescription.norm).toEqual(norm)
-        expect(prescription.items).toEqual(items)
-    })
+  it('can be obtained from an unknown object', () => {
+    prescription = Prescription.fromObject(testPrescription)
+    expect(prescription.id).toEqual(id)
+    expect(prescription.getIssuedDate()).toEqual(issuedDate)
+    expect(prescription.getSoldDate()).toEqual(soldDate)
+    expect(prescription.getAuditedDate()).toEqual(auditedDate)
+    expect(prescription.prolongedTreatment).toEqual(prolongedTreatment)
+    expect(prescription.diagnosis).toEqual(diagnosis)
+    expect(prescription.ttl).toEqual(ttl)
+    expect(prescription.institution).toEqual(institution)
+    expect(prescription.affiliate).toEqual(affiliate)
+    expect(prescription.doctor).toEqual(doctor)
+    expect(prescription.medicalInsurance).toEqual(medicalInsurance)
+    expect(prescription.status).toEqual(status)
+    expect(prescription.norm).toEqual(norm)
+    expect(prescription.items).toEqual(items)
+  })
 
-    it('when you set a valid issue date to a prescription it stores it like a moment', () => {
-        const issuedDate = '01/01/1998 23:00'
-        expect(prescription.issuedDate).toBeNull()
-        prescription.setIssuedDate(issuedDate)
-        expect(moment.isMoment(prescription.issuedDate)).toBeTruthy()
-        expect(prescription.issuedDate.format(formats.dateTimeFormat)).toEqual(issuedDate)
-    })
+  it('when you set a valid issue date to a prescription it stores it like a moment', () => {
+    const issuedDate = '01/01/1998 23:00'
+    expect(prescription.issuedDate).toBeNull()
+    prescription.setIssuedDate(issuedDate)
+    expect(moment.isMoment(prescription.issuedDate)).toBeTruthy()
+    expect(prescription.issuedDate.format(formats.dateTimeFormat)).toEqual(issuedDate)
+  })
 
-    it('when you set an invalid issue date to a prescription it stores a null', () => {
-        const issuedDate = '30/02/1998 23:00'
-        expect(prescription.issuedDate).toBeNull()
-        prescription.setIssuedDate(issuedDate)
-        expect(prescription.issuedDate).toBeNull()
-    })
+  it('when you set an invalid issue date to a prescription it stores a null', () => {
+    const issuedDate = '30/02/1998 23:00'
+    expect(prescription.issuedDate).toBeNull()
+    prescription.setIssuedDate(issuedDate)
+    expect(prescription.issuedDate).toBeNull()
+  })
 
-    it('when you get the issued date from a prescription that has an issued date it returns a string representation', () => {
-        const issuedDate = '01/01/1998 23:00'
-        prescription.setIssuedDate(issuedDate)
-        expect(prescription.getIssuedDate()).toEqual(issuedDate)
-    })
+  it('when you get the issued date from a prescription that has an issued date it returns a string representation', () => {
+    const issuedDate = '01/01/1998 23:00'
+    prescription.setIssuedDate(issuedDate)
+    expect(prescription.getIssuedDate()).toEqual(issuedDate)
+  })
 
-    it('when you get the issued date from a prescription that hasn´t an issued date it returns a null', () => {
-        prescription.setIssuedDate(null)
-        expect(prescription.getIssuedDate()).toBeNull()
-    })
+  it('when you get the issued date from a prescription that hasn´t an issued date it returns a null', () => {
+    prescription.setIssuedDate(null)
+    expect(prescription.getIssuedDate()).toBeNull()
+  })
 
-    it('when you set a valid sold date to a prescription it stores it like a moment', () => {
-        const soldDate = '01/01/1998 23:00'
-        expect(prescription.soldDate).toBeNull()
-        prescription.setSoldDate(soldDate)
-        expect(moment.isMoment(prescription.soldDate)).toBeTruthy()
-        expect(prescription.soldDate.format(formats.dateTimeFormat)).toEqual(soldDate)
-    })
+  it('when you set a valid sold date to a prescription it stores it like a moment', () => {
+    const soldDate = '01/01/1998 23:00'
+    expect(prescription.soldDate).toBeNull()
+    prescription.setSoldDate(soldDate)
+    expect(moment.isMoment(prescription.soldDate)).toBeTruthy()
+    expect(prescription.soldDate.format(formats.dateTimeFormat)).toEqual(soldDate)
+  })
 
-    it('when you set an invalid sold date to a prescription it stores a null', () => {
-        const soldDate = '30/02/1998 23:00'
-        expect(prescription.soldDate).toBeNull()
-        prescription.setSoldDate(soldDate)
-        expect(prescription.soldDate).toBeNull()
-    })
+  it('when you set an invalid sold date to a prescription it stores a null', () => {
+    const soldDate = '30/02/1998 23:00'
+    expect(prescription.soldDate).toBeNull()
+    prescription.setSoldDate(soldDate)
+    expect(prescription.soldDate).toBeNull()
+  })
 
-    it('when you get the sold date from a prescription that has a sold date it returns a string representation', () => {
-        const soldDate = '01/01/1998 23:00'
-        prescription.setSoldDate(soldDate)
-        expect(prescription.getSoldDate()).toEqual(soldDate)
-    })
+  it('when you get the sold date from a prescription that has a sold date it returns a string representation', () => {
+    const soldDate = '01/01/1998 23:00'
+    prescription.setSoldDate(soldDate)
+    expect(prescription.getSoldDate()).toEqual(soldDate)
+  })
 
-    it('when you get the sold date from a prescription that hasn´t a sold date it returns a null', () => {
-        prescription.setSoldDate(null)
-        expect(prescription.getSoldDate()).toBeNull()
-    })
+  it('when you get the sold date from a prescription that hasn´t a sold date it returns a null', () => {
+    prescription.setSoldDate(null)
+    expect(prescription.getSoldDate()).toBeNull()
+  })
 
-    it('when you set a valid audited date to a prescription it stores it like a moment', () => {
-        const auditedDate = '01/01/1998 23:00'
-        expect(prescription.auditedDate).toBeNull()
-        prescription.setAuditedDate(auditedDate)
-        expect(moment.isMoment(prescription.auditedDate)).toBeTruthy()
-        expect(prescription.auditedDate.format(formats.dateTimeFormat)).toEqual(auditedDate)
-    })
+  it('when you set a valid audited date to a prescription it stores it like a moment', () => {
+    const auditedDate = '01/01/1998 23:00'
+    expect(prescription.auditedDate).toBeNull()
+    prescription.setAuditedDate(auditedDate)
+    expect(moment.isMoment(prescription.auditedDate)).toBeTruthy()
+    expect(prescription.auditedDate.format(formats.dateTimeFormat)).toEqual(auditedDate)
+  })
 
-    it('when you set an invalid audited date to a prescription it stores a null', () => {
-        const auditedDate = '30/02/1998 23:00'
-        expect(prescription.auditedDate).toBeNull()
-        prescription.setAuditedDate(auditedDate)
-        expect(prescription.auditedDate).toBeNull()
-    })
+  it('when you set an invalid audited date to a prescription it stores a null', () => {
+    const auditedDate = '30/02/1998 23:00'
+    expect(prescription.auditedDate).toBeNull()
+    prescription.setAuditedDate(auditedDate)
+    expect(prescription.auditedDate).toBeNull()
+  })
 
-    it('when you get the audited date from a prescription that has an audited date it returns a string representation', () => {
-        const auditedDate = '01/01/1998 23:00'
-        prescription.setAuditedDate(auditedDate)
-        expect(prescription.getAuditedDate()).toEqual(auditedDate)
-    })
+  it('when you get the audited date from a prescription that has an audited date it returns a string representation', () => {
+    const auditedDate = '01/01/1998 23:00'
+    prescription.setAuditedDate(auditedDate)
+    expect(prescription.getAuditedDate()).toEqual(auditedDate)
+  })
 
-    it('when you get the audited date from a prescription that hasn´t an audited date it returns a null', () => {
-        prescription.setAuditedDate(null)
-        expect(prescription.getAuditedDate()).toBeNull()
-    })
+  it('when you get the audited date from a prescription that hasn´t an audited date it returns a null', () => {
+    prescription.setAuditedDate(null)
+    expect(prescription.getAuditedDate()).toBeNull()
+  })
 
-    //TODO: Testear asignarle un afiliado, un medico, una obra social, items, etc..
+  // TODO: Testear asignarle un afiliado, un medico, una obra social, items, etc..
 })

--- a/test/unit/middlewares/error-handler.spec.js
+++ b/test/unit/middlewares/error-handler.spec.js
@@ -2,57 +2,57 @@ const errorHandler = require('../../../src/middlewares/error-handler')
 const errors = require('../../../src/utils/errors')
 
 describe('when err passed to middleware errorHandler', () => {
-    let err = null
-    let req = null
-    let res = null
-    let next = null
+  let err = null
+  let req = null
+  let res = null
+  let next = null
 
+  beforeEach(() => {
+    err = errors.newBadRequestError()
+    req = { app: { locals: { logger: { info: () => {} } } } }
+    res = {
+      json: jest.fn((json) => {}),
+      send: jest.fn((data) => {}),
+      status: jest.fn(status => res),
+    }
+    next = jest.fn((error) => {})
+  })
+
+  describe('and res.headersSent is true', () => {
     beforeEach(() => {
-        err = errors.newBadRequestError()
-        req = {app: {locals:{logger:{info: () => {}}}}}
-        res = {
-            json: jest.fn((json) => {}),
-            send: jest.fn((data) => {}),
-            status: jest.fn((status) => {return res})
-        }
-        next = jest.fn((error) => {})
+      res.headersSent = true
+    })
+    it('calls next handler with err as argument', () => {
+      errorHandler(err, req, res, next)
+      expect(next.mock.calls.length).toBe(1)
+      expect(next.mock.calls[0][0]).toEqual(err)
     })
 
-    describe('and res.headersSent is true', () => {
-        beforeEach(() => {
-            res.headersSent = true
-        })
-        it('calls next handler with err as argument', () => {
-            errorHandler(err, req, res, next)
-            expect(next.mock.calls.length).toBe(1)
-            expect(next.mock.calls[0][0]).toEqual(err)
-        })
+    it('doesn´t call res.json', () => {
+      errorHandler(err, req, res, next)
+      expect(res.json.mock.calls.length).toBe(0)
+    })
+  })
 
-        it('doesn´t call res.json', () => {
-            errorHandler(err, req, res, next)
-            expect(res.json.mock.calls.length).toBe(0)
-        })
+  describe('and res.headersSent is false', () => {
+    beforeEach(() => {
+      res.headersSent = false
+    })
+    it('doesn`t call next handler', () => {
+      errorHandler(err, req, res, next)
+      expect(next.mock.calls.length).toBe(0)
     })
 
-    describe('and res.headersSent is false', () => {
-        beforeEach(() => {
-            res.headersSent = false
-        })
-        it('doesn`t call next handler', () => {
-            errorHandler(err, req, res, next)
-            expect(next.mock.calls.length).toBe(0)
-        })
-
-        it('calls res.status', () => {
-            errorHandler(err, req, res, next)
-            expect(res.status.mock.calls.length).toBe(1)
-            expect(res.status.mock.calls[0][0]).toBeTruthy()
-        })
-
-        it('calls res.json', () => {
-            errorHandler(err, req, res, next)
-            expect(res.json.mock.calls.length).toBe(1)
-            expect(res.json.mock.calls[0][0]).toBeTruthy()
-        })
+    it('calls res.status', () => {
+      errorHandler(err, req, res, next)
+      expect(res.status.mock.calls.length).toBe(1)
+      expect(res.status.mock.calls[0][0]).toBeTruthy()
     })
+
+    it('calls res.json', () => {
+      errorHandler(err, req, res, next)
+      expect(res.json.mock.calls.length).toBe(1)
+      expect(res.json.mock.calls[0][0]).toBeTruthy()
+    })
+  })
 })

--- a/test/unit/repositories/medicalInsuranceRepository.spec.js
+++ b/test/unit/repositories/medicalInsuranceRepository.spec.js
@@ -1,26 +1,25 @@
-const {MedicalInsuranceRepository} = require('../../../src/repositories/medicalInsuranceRepository')
+const { MedicalInsuranceRepository } = require('../../../src/repositories/medicalInsuranceRepository')
 
 const medicalInsurancesValue = [
-    {
-        id:0,
-        description:"OSDE"
-    },
-    {
-        id:0,
-        description:"SWISS MEDICAL"
-    }
+  {
+    id: 0,
+    description: 'OSDE',
+  },
+  {
+    id: 0,
+    description: 'SWISS MEDICAL',
+  },
 ]
-describe('MedicalInsuranceRepository',()=>{
-    describe('when has any medical insurance',()=>{
-        beforeAll(()=>{
-            MedicalInsuranceRepository.medicalInsurances = medicalInsurancesValue
-        })
-        describe('and ask for all',()=>{
-            it('respond with all the medical insurances', async ()=>{
-                const result = await MedicalInsuranceRepository.getAll();
-                expect(result).toEqual(medicalInsurancesValue)
-            })
-        });
-        
+describe('MedicalInsuranceRepository', () => {
+  describe('when has any medical insurance', () => {
+    beforeAll(() => {
+      MedicalInsuranceRepository.medicalInsurances = medicalInsurancesValue
     })
-});
+    describe('and ask for all', () => {
+      it('respond with all the medical insurances', async () => {
+        const result = await MedicalInsuranceRepository.getAll()
+        expect(result).toEqual(medicalInsurancesValue)
+      })
+    })
+  })
+})

--- a/test/unit/repositories/prescriptions-repository.spec.js
+++ b/test/unit/repositories/prescriptions-repository.spec.js
@@ -1,160 +1,136 @@
-const {PrescriptionRepository} = require('../../../src/repositories/prescriptions-repository')
-const {Prescription} = require('../../../src/domain/prescription')
-const {states} = require('../../../src/state-machine/state')
+const { PrescriptionRepository } = require('../../../src/repositories/prescriptions-repository')
+const { Prescription } = require('../../../src/domain/prescription')
+const { states } = require('../../../src/state-machine/state')
 
 describe('When creating a prescription', () => {
-    let prescription = new Prescription()
+  let prescription = new Prescription()
+  beforeEach(() => {
+    prescription = new Prescription()
+    return PrescriptionRepository.reset()
+  })
+
+  describe('and prescription hasn`t an id', () => {
     beforeEach(() => {
-        prescription = new Prescription()
-        return PrescriptionRepository.reset()
+      prescription.id = null
     })
 
-    describe('and prescription hasn`t an id', () => {
-        beforeEach(() => {
-            prescription.id = null
-        })
+    it('PrescriptionRepositoy assigns an id to it', () => PrescriptionRepository.create(prescription)
+      .then((pres) => {
+        expect(pres.id).not.toBeNull()
+      }))
 
-        it('PrescriptionRepositoy assigns an id to it', ()=> {
-            return PrescriptionRepository.create(prescription)
-            .then(pres => {
-                expect(pres.id).not.toBeNull()
-            })
-        })
+    it('PrescriptionRepositoy stores it and increment the repo`s count', () => PrescriptionRepository.create(prescription)
+      .then(pres => PrescriptionRepository.count()
+        .then((cantidad) => {
+          expect(cantidad).toBe(1)
+        })))
+  })
 
-        it('PrescriptionRepositoy stores it and increment the repo`s count', ()=> {
-            return PrescriptionRepository.create(prescription)
-            .then(pres => {
-                return PrescriptionRepository.count()
-                .then(cantidad => {
-                    expect(cantidad).toBe(1)
-                })
-            })
-        })
+  describe('and prescription has an id', () => {
+    beforeEach(() => {
+      prescription.id = 1
     })
 
-    describe('and prescription has an id', () => {
-        beforeEach(() => {
-            prescription.id = 1
-        })
+    it('PrescriptionRepositoy reject the promise with an error', () => expect(PrescriptionRepository.create(prescription)).rejects.not.toBeNull())
 
-        it('PrescriptionRepositoy reject the promise with an error', ()=> {
-            return expect(PrescriptionRepository.create(prescription)).rejects.not.toBeNull()
-        })
-
-        it('PrescriptionRepositoy doesn`t increment the repo`s count', ()=> {
-            return PrescriptionRepository.create(prescription)
-            .catch(err => {
-                return PrescriptionRepository.count()
-                .then(cantidad => {
-                    expect(cantidad).toBe(0)
-                })
-            })
-        })
-    })
+    it('PrescriptionRepositoy doesn`t increment the repo`s count', () => PrescriptionRepository.create(prescription)
+      .catch(err => PrescriptionRepository.count()
+        .then((cantidad) => {
+          expect(cantidad).toBe(0)
+        })))
+  })
 })
 
 let prescription = new Prescription()
 beforeEach(() => {
-    prescription = new Prescription()
-    return PrescriptionRepository.reset()
+  prescription = new Prescription()
+  return PrescriptionRepository.reset()
 })
 
-test('when no prescriptions where created, PrescriptionRepository returns an empty array', () => {
-    return expect(PrescriptionRepository.getAll()).resolves.toEqual([])
-})
+test('when no prescriptions where created, PrescriptionRepository returns an empty array', () => expect(PrescriptionRepository.getAll()).resolves.toEqual([]))
 
-test('when prescriptions where created, PrescriptionRepository returns all of the prescriptions', () => {
-    return PrescriptionRepository.create(new Prescription())
-    .then(prescription1 => {
-        PrescriptionRepository.create(new Prescription())
-        .then(prescription2 => {
-            PrescriptionRepository.getAll()
-            .then(prescriptions => {
-                expect(prescriptions).toContain(prescription1)
-                expect(prescriptions).toContain(prescription2)
-                expect(prescriptions.length).toBe(2)
-            })
-        })
-    })
-})
+test('when prescriptions where created, PrescriptionRepository returns all of the prescriptions', () => PrescriptionRepository.create(new Prescription())
+  .then((prescription1) => {
+    PrescriptionRepository.create(new Prescription())
+      .then((prescription2) => {
+        PrescriptionRepository.getAll()
+          .then((prescriptions) => {
+            expect(prescriptions).toContain(prescription1)
+            expect(prescriptions).toContain(prescription2)
+            expect(prescriptions.length).toBe(2)
+          })
+      })
+  }))
 
 describe('when you create some prescriptions by PrescriptionRepository', () => {
-    let prescription1 = new Prescription()
-    let prescription2 = new Prescription()
-    let prescription3 = new Prescription()
-    beforeEach(() => {
-        prescription1 = new Prescription()
-        prescription1.status = states.ISSUED.status
-        prescription2 = new Prescription()
-        prescription2.status = states.CONFIRMED.status
-        prescription3 = new Prescription()
-        prescription3.status = states.ISSUED.status
-        PrescriptionRepository.reset()
-        .then(_ => {
-            return Promise.all([
-                PrescriptionRepository.create(prescription1).then(pres => {prescription1 = pres.clone(); return pres}),
-                PrescriptionRepository.create(prescription2).then(pres => {prescription2 = pres.clone(); return pres}),
-                PrescriptionRepository.create(prescription3).then(pres => {prescription3 = pres.clone(); return pres})
-            ])
-        })
+  let prescription1 = new Prescription()
+  let prescription2 = new Prescription()
+  let prescription3 = new Prescription()
+  beforeEach(() => {
+    prescription1 = new Prescription()
+    prescription1.status = states.ISSUED.status
+    prescription2 = new Prescription()
+    prescription2.status = states.CONFIRMED.status
+    prescription3 = new Prescription()
+    prescription3.status = states.ISSUED.status
+    PrescriptionRepository.reset()
+      .then(_ => Promise.all([
+        PrescriptionRepository.create(prescription1).then((pres) => { prescription1 = pres.clone(); return pres }),
+        PrescriptionRepository.create(prescription2).then((pres) => { prescription2 = pres.clone(); return pres }),
+        PrescriptionRepository.create(prescription3).then((pres) => { prescription3 = pres.clone(); return pres }),
+      ]))
+  })
+
+  describe('and want to get one by id', () => {
+    describe('and it`s a valid id', () => {
+      it('it returns the prescription', () => PrescriptionRepository.getById(prescription1.id)
+        .then((pres) => {
+          expect(pres.id).toBe(prescription1.id)
+        }))
     })
 
-    describe('and want to get one by id', () => {
-        describe('and it`s a valid id', () => {
-            it('it returns the prescription', () => {
-                return PrescriptionRepository.getById(prescription1.id)
-                .then(pres => {
-                    expect(pres.id).toBe(prescription1.id)
-                })
-            })
-        })
+    describe('and it`s an invalid id', () => {
+      it('it rejects the search', () => expect(PrescriptionRepository.getById(prescription1.id + 9999)).rejects.not.toBeNull())
+    })
+  })
 
-        describe('and it`s an invalid id', () => {
-            it('it rejects the search', () => {
-                return expect(PrescriptionRepository.getById(prescription1.id + 9999)).rejects.not.toBeNull()
-            })
-        })
+  describe('and want to update one', () => {
+    describe('and has a valid id', () => {
+      it('it updates it and returns the prescription', () => {
+        const prescription = prescription1.clone()
+        prescription.setIssuedDate('12/12/1990 00:00')
+        prescription.prolongedTreatment = true
+        prescription.status = 'jaja'
+        return PrescriptionRepository.update(prescription)
+          .then((pres) => {
+            expect(pres.getIssuedDate()).toBe(prescription.getIssuedDate())
+            expect(pres.prolongedTreatment).toBe(prescription.prolongedTreatment)
+            expect(pres.status).toBe(prescription.status)
+          })
+      })
     })
 
-    describe('and want to update one', () => {
-        describe('and has a valid id', () => {
-            it('it updates it and returns the prescription', () => {
-                const prescription = prescription1.clone()
-                prescription.setIssuedDate('12/12/1990 00:00')
-                prescription.prolongedTreatment = true
-                prescription.status = 'jaja'
-                return PrescriptionRepository.update(prescription)
-                .then(pres => {
-                    expect(pres.getIssuedDate()).toBe(prescription.getIssuedDate())
-                    expect(pres.prolongedTreatment).toBe(prescription.prolongedTreatment)
-                    expect(pres.status).toBe(prescription.status)
-                })
-            })
-        })
-
-        describe('and has an invalid id', () => {
-            it('it rejects the update', () => {
-                const prescription = prescription1.clone()
-                prescription.id = prescription.id + 9999
-                return expect(PrescriptionRepository.update(prescription)).rejects.not.toBeNull()
-            })
-        })
+    describe('and has an invalid id', () => {
+      it('it rejects the update', () => {
+        const prescription = prescription1.clone()
+        prescription.id += 9999
+        return expect(PrescriptionRepository.update(prescription)).rejects.not.toBeNull()
+      })
     })
+  })
 
-    describe('and wants to get some by status', () => {
-        it('it returns the matching prescriptions', () => {
-            return PrescriptionRepository.getByStatus(states.ISSUED.status)
-            .then(prescriptions => {
-                expect(prescriptions.map((pres) => pres.id)).toContainEqual(prescription1.id)
-                expect(prescriptions.map((pres) => pres.id)).toContainEqual(prescription3.id)
-                expect(prescriptions.every((pres) => {return pres.status = states.ISSUED.status})).toBeTruthy()
-                return PrescriptionRepository.getByStatus(states.PARTIALLY_RECEIVED.status)
-                .then(prescriptions => {
-                    expect(prescriptions.length).toBe(0)
-                })
-            })
-        })
-    })
+  describe('and wants to get some by status', () => {
+    it('it returns the matching prescriptions', () => PrescriptionRepository.getByStatus(states.ISSUED.status)
+      .then((prescriptions) => {
+        expect(prescriptions.map(pres => pres.id)).toContainEqual(prescription1.id)
+        expect(prescriptions.map(pres => pres.id)).toContainEqual(prescription3.id)
+        expect(prescriptions.every(pres => pres.status = states.ISSUED.status)).toBeTruthy()
+        return PrescriptionRepository.getByStatus(states.PARTIALLY_RECEIVED.status)
+          .then((prescriptions) => {
+            expect(prescriptions.length).toBe(0)
+          })
+      }))
+  })
 
-    //TODO: hacer el resto de los test de busqueda por ejemplo
+  // TODO: hacer el resto de los test de busqueda por ejemplo
 })

--- a/test/unit/state-machine/state.spec.js
+++ b/test/unit/state-machine/state.spec.js
@@ -1,259 +1,259 @@
-const {states} = require('../../../src/state-machine/state')
-const {Prescription} = require('../../../src/domain/prescription')
-const {_errors} = require('../../../src/utils/errors')
-const {codes} = require('../../../src/codes/entities-codes')
+const { states } = require('../../../src/state-machine/state')
+const { Prescription } = require('../../../src/domain/prescription')
+const { _errors } = require('../../../src/utils/errors')
+const { codes } = require('../../../src/codes/entities-codes')
 
 test('State ISSUED has a status defined', () => {
-    expect(states.ISSUED.status).toBeDefined()
-    expect(states.ISSUED.status).toBeTruthy()
+  expect(states.ISSUED.status).toBeDefined()
+  expect(states.ISSUED.status).toBeTruthy()
 })
 const getNewPrescription = () => {
-    let prescription = new Prescription()
-    return prescription
+  const prescription = new Prescription()
+  return prescription
 }
 const getNewFullForIssued = () => {
-    let prescription = new Prescription()
-    prescription.id = null
-    prescription.setIssuedDate('01/01/2000 10:10')
-    prescription.setSoldDate('02/01/2000 10:10')
-    prescription.setAuditedDate('03/01/2000 10:10')
-    prescription.prolongedTreatment = false
-    prescription.diagnosis = 'diagnostico'
-    prescription.ttl = 30
-    prescription.institution = {id: 1}
-    prescription.affiliate = {id: 1}
-    prescription.doctor = {id: 1}
-    prescription.medicalInsurance = {id: 1}
-    prescription.status = states.ISSUED.status
-    prescription.norm = {id: 1}
-    prescription.addItem({
-        "prescribed": {
-          "quantity": 99,
-          "medicine": {
-            "id": 1
-          }
-        }
-      })
-    return prescription
+  const prescription = new Prescription()
+  prescription.id = null
+  prescription.setIssuedDate('01/01/2000 10:10')
+  prescription.setSoldDate('02/01/2000 10:10')
+  prescription.setAuditedDate('03/01/2000 10:10')
+  prescription.prolongedTreatment = false
+  prescription.diagnosis = 'diagnostico'
+  prescription.ttl = 30
+  prescription.institution = { id: 1 }
+  prescription.affiliate = { id: 1 }
+  prescription.doctor = { id: 1 }
+  prescription.medicalInsurance = { id: 1 }
+  prescription.status = states.ISSUED.status
+  prescription.norm = { id: 1 }
+  prescription.addItem({
+    prescribed: {
+      quantity: 99,
+      medicine: {
+        id: 1,
+      },
+    },
+  })
+  return prescription
 }
 const getNewPrescriptionForIssued = () => {
-    let prescription = new Prescription()
-    prescription.setIssuedDate('01/01/2000 10:10')
-    prescription.prolongedTreatment = false
-    prescription.ttl = 30
-    prescription.institution = {id: 1}
-    prescription.affiliate = {id: 1}
-    prescription.doctor = {id: 1}
-    prescription.medicalInsurance = {id: 1}
-    prescription.norm = {id: 1}
-    prescription.addItem({
-        prescribed: {
-          quantity: 99,
-          medicine: {
-            id: 1
-          }
-        }
-      })
-    return prescription
+  const prescription = new Prescription()
+  prescription.setIssuedDate('01/01/2000 10:10')
+  prescription.prolongedTreatment = false
+  prescription.ttl = 30
+  prescription.institution = { id: 1 }
+  prescription.affiliate = { id: 1 }
+  prescription.doctor = { id: 1 }
+  prescription.medicalInsurance = { id: 1 }
+  prescription.norm = { id: 1 }
+  prescription.addItem({
+    prescribed: {
+      quantity: 99,
+      medicine: {
+        id: 1,
+      },
+    },
+  })
+  return prescription
 }
 describe('when state ISSUED has to validate a prescription', () => {
-    describe('and prescription is null, undefined or not truthy', () => {
-        it('it throws an error', () => {
-            expect(() => {states.ISSUED.validate()}).toThrow()
-            expect(() => {states.ISSUED.validate(null)}).toThrow()
-            expect(() => {states.ISSUED.validate('')}).toThrow()
-        })
+  describe('and prescription is null, undefined or not truthy', () => {
+    it('it throws an error', () => {
+      expect(() => { states.ISSUED.validate() }).toThrow()
+      expect(() => { states.ISSUED.validate(null) }).toThrow()
+      expect(() => { states.ISSUED.validate('') }).toThrow()
     })
+  })
 
-    describe('and prescription has a status setted', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.status = 'XXX'
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(1)
-                const error = errors[0]
-                expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
-                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.status)
-            }
-        })
+  describe('and prescription has a status setted', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.status = 'XXX'
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(1)
+        const error = errors[0]
+        expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
+        expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.status)
+      }
     })
+  })
 
-    describe('and prescription hasn`t an issuedDate', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.setIssuedDate(null)
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(1)
-                const error = errors[0]
-                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
-                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.issuedDate)
-            }
-        })
+  describe('and prescription hasn`t an issuedDate', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.setIssuedDate(null)
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(1)
+        const error = errors[0]
+        expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+        expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.issuedDate)
+      }
     })
+  })
 
-    describe('and prescription hasn`t a ttl', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.ttl = null
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(1)
-                const error = errors[0]
-                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
-                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.ttl)
-            }
-        })
+  describe('and prescription hasn`t a ttl', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.ttl = null
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(1)
+        const error = errors[0]
+        expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+        expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.ttl)
+      }
     })
+  })
 
-    describe('and prescription hasn`t an affiliate', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.affiliate = null
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(2)
-                // const error = errors[0]
-                // expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
-                // expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                // expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.affiliate)
-            }
-        })
+  describe('and prescription hasn`t an affiliate', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.affiliate = null
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(2)
+        // const error = errors[0]
+        // expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+        // expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        // expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.affiliate)
+      }
     })
+  })
 
-    describe('and prescription hasn`t a doctor', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.doctor = null
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(2)
-                // const error = errors[0]
-                // expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
-                // expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                // expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.doctor)
-            }
-        })
+  describe('and prescription hasn`t a doctor', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.doctor = null
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(2)
+        // const error = errors[0]
+        // expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+        // expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        // expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.doctor)
+      }
     })
+  })
 
-    describe('and prescription hasn`t a medicalInsurance', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.medicalInsurance = null
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(2)
-                // const error = errors[0]
-                // expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
-                // expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                // expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.medicalInsurance)
-            }
-        })
+  describe('and prescription hasn`t a medicalInsurance', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.medicalInsurance = null
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(2)
+        // const error = errors[0]
+        // expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+        // expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        // expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.medicalInsurance)
+      }
     })
+  })
 
-    describe('and prescription hasn`t a norm', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.norm = null
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(1)
-                const error = errors[0]
-                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
-                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.norm)
-            }
-        })
+  describe('and prescription hasn`t a norm', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.norm = null
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(1)
+        const error = errors[0]
+        expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+        expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.norm)
+      }
     })
+  })
 
-    describe('and prescription has no items setted', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.items = []
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(1)
-                const error = errors[0]
-                expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
-                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.items)
-            }
-        })
+  describe('and prescription has no items setted', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.items = []
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(1)
+        const error = errors[0]
+        expect(error.code).toBe(_errors.NULL_OR_EMPTY_VALUE_ERROR.code)
+        expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.items)
+      }
     })
+  })
 
-    describe('and prescription has a soldDate', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.setSoldDate('02/01/01 10:10')
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(1)
-                const error = errors[0]
-                expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
-                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.soldDate)
-            }
-        })
+  describe('and prescription has a soldDate', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.setSoldDate('02/01/01 10:10')
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(1)
+        const error = errors[0]
+        expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
+        expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.soldDate)
+      }
     })
+  })
 
-    describe('and prescription has a auditedDate', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.setAuditedDate('03/01/01 10:10')
-        it('it throws an error that specifies an error on field', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(1)
-                const error = errors[0]
-                expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
-                expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
-                expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.auditedDate)
-            }
-        })
+  describe('and prescription has a auditedDate', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.setAuditedDate('03/01/01 10:10')
+    it('it throws an error that specifies an error on field', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(1)
+        const error = errors[0]
+        expect(error.code).toBe(_errors.INVALID_VALUE_ERROR.code)
+        expect(error.cause.entity).toBe(codes.PRESCRIPTION.name)
+        expect(error.cause.field).toBe(codes.PRESCRIPTION.fields.auditedDate)
+      }
     })
+  })
 
-    describe('and prescription has various errors', () => {
-        const prescription = getNewPrescriptionForIssued()
-        prescription.status = states.ISSUED.status
-        prescription.setIssuedDate(null)
-        it('it throws an error that specifies all errors', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).toThrow()
-            try {
-                states.ISSUED.validate(prescription)
-            } catch (errors) {
-                expect(errors.length).toBe(2)
-            }
-        })
+  describe('and prescription has various errors', () => {
+    const prescription = getNewPrescriptionForIssued()
+    prescription.status = states.ISSUED.status
+    prescription.setIssuedDate(null)
+    it('it throws an error that specifies all errors', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).toThrow()
+      try {
+        states.ISSUED.validate(prescription)
+      } catch (errors) {
+        expect(errors.length).toBe(2)
+      }
     })
+  })
 
-    describe('and prescription is ok', () => {
-        const prescription = getNewPrescriptionForIssued()
-        it('it validates the prescription and leaves it untouched', () => {
-            expect(() => {states.ISSUED.validate(prescription)}).not.toThrow()
-            expect(prescription).toEqual(getNewPrescriptionForIssued())
-        })
+  describe('and prescription is ok', () => {
+    const prescription = getNewPrescriptionForIssued()
+    it('it validates the prescription and leaves it untouched', () => {
+      expect(() => { states.ISSUED.validate(prescription) }).not.toThrow()
+      expect(prescription).toEqual(getNewPrescriptionForIssued())
     })
+  })
 })

--- a/test/unit/utils/errors.spec.js
+++ b/test/unit/utils/errors.spec.js
@@ -1,171 +1,172 @@
+/* eslint-disable no-underscore-dangle */
 const errors = require('../../../src/utils/errors')
 
 test('new unexpectedError error can be created with default message, status and cause', () => {
-    const error = errors.newUnexpectedError()
-    expect(error.message).toBe(errors._errors.UNEXPECTED_ERROR.message)
-    expect(error.status).toBe(errors._errors.UNEXPECTED_ERROR.status)
-    expect(error.cause).toEqual(errors._errors.UNEXPECTED_ERROR.cause)
+  const error = errors.newUnexpectedError()
+  expect(error.message).toBe(errors._errors.UNEXPECTED_ERROR.message)
+  expect(error.status).toBe(errors._errors.UNEXPECTED_ERROR.status)
+  expect(error.cause).toEqual(errors._errors.UNEXPECTED_ERROR.cause)
 })
 
 test('new unexpectedError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newUnexpectedError(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newUnexpectedError(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new genericError error can be created with default message, status and cause', () => {
-    const error = errors.newGenericError()
-    expect(error.message).toBe(errors._errors.GENERIC_ERROR.message)
-    expect(error.status).toBe(errors._errors.GENERIC_ERROR.status)
-    expect(error.cause).toEqual(errors._errors.GENERIC_ERROR.cause)
+  const error = errors.newGenericError()
+  expect(error.message).toBe(errors._errors.GENERIC_ERROR.message)
+  expect(error.status).toBe(errors._errors.GENERIC_ERROR.status)
+  expect(error.cause).toEqual(errors._errors.GENERIC_ERROR.cause)
 })
 
 test('new genericError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newGenericError(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newGenericError(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new duplicatedValueError error can be created with default message, status and cause', () => {
-    const error = errors.newDuplicatedValueError()
-    expect(error.message).toBe(errors._errors.DUPLICATED_VALUE_ERROR.message)
-    expect(error.status).toBe(errors._errors.DUPLICATED_VALUE_ERROR.status)
-    expect(error.cause).toEqual(errors._errors.DUPLICATED_VALUE_ERROR.cause)
+  const error = errors.newDuplicatedValueError()
+  expect(error.message).toBe(errors._errors.DUPLICATED_VALUE_ERROR.message)
+  expect(error.status).toBe(errors._errors.DUPLICATED_VALUE_ERROR.status)
+  expect(error.cause).toEqual(errors._errors.DUPLICATED_VALUE_ERROR.cause)
 })
 
 test('new duplicatedValueError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newDuplicatedValueError(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newDuplicatedValueError(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new nullOrEmptyError error can be created with default message, status and cause', () => {
-    const error = errors.newNullOrEmptyError()
-    expect(error.message).toBe(errors._errors.NULL_OR_EMPTY_VALUE_ERROR.message)
-    expect(error.status).toBe(errors._errors.NULL_OR_EMPTY_VALUE_ERROR.status)
-    expect(error.cause).toEqual(errors._errors.NULL_OR_EMPTY_VALUE_ERROR.cause)
+  const error = errors.newNullOrEmptyError()
+  expect(error.message).toBe(errors._errors.NULL_OR_EMPTY_VALUE_ERROR.message)
+  expect(error.status).toBe(errors._errors.NULL_OR_EMPTY_VALUE_ERROR.status)
+  expect(error.cause).toEqual(errors._errors.NULL_OR_EMPTY_VALUE_ERROR.cause)
 })
 
 test('new nullOrEmptyError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newNullOrEmptyError(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newNullOrEmptyError(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new invalidValueError error can be created with default message, status and cause', () => {
-    const error = errors.newInvalidValueError()
-    expect(error.message).toBe(errors._errors.INVALID_VALUE_ERROR.message)
-    expect(error.status).toBe(errors._errors.INVALID_VALUE_ERROR.status)
-    expect(error.cause).toEqual(errors._errors.INVALID_VALUE_ERROR.cause)
+  const error = errors.newInvalidValueError()
+  expect(error.message).toBe(errors._errors.INVALID_VALUE_ERROR.message)
+  expect(error.status).toBe(errors._errors.INVALID_VALUE_ERROR.status)
+  expect(error.cause).toEqual(errors._errors.INVALID_VALUE_ERROR.cause)
 })
 
 test('new invalidValueError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newInvalidValueError(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newInvalidValueError(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new entityAlreadyCreated error can be created with default message, status and cause', () => {
-    const error = errors.newEntityAlreadyCreated()
-    expect(error.message).toBe(errors._errors.ENTITY_ALREADY_CREATED.message)
-    expect(error.status).toBe(errors._errors.ENTITY_ALREADY_CREATED.status)
-    expect(error.cause).toEqual(errors._errors.ENTITY_ALREADY_CREATED.cause)
+  const error = errors.newEntityAlreadyCreated()
+  expect(error.message).toBe(errors._errors.ENTITY_ALREADY_CREATED.message)
+  expect(error.status).toBe(errors._errors.ENTITY_ALREADY_CREATED.status)
+  expect(error.cause).toEqual(errors._errors.ENTITY_ALREADY_CREATED.cause)
 })
 
 test('new entityAlreadyCreated error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newEntityAlreadyCreated(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newEntityAlreadyCreated(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new notFoundError error can be created with default message, status and cause', () => {
-    const error = errors.newNotFoundError()
-    expect(error.message).toBe(errors._errors.NOT_FOUND_ERROR.message)
-    expect(error.status).toBe(errors._errors.NOT_FOUND_ERROR.status)
-    expect(error.cause).toEqual(errors._errors.NOT_FOUND_ERROR.cause)
+  const error = errors.newNotFoundError()
+  expect(error.message).toBe(errors._errors.NOT_FOUND_ERROR.message)
+  expect(error.status).toBe(errors._errors.NOT_FOUND_ERROR.status)
+  expect(error.cause).toEqual(errors._errors.NOT_FOUND_ERROR.cause)
 })
 
 test('new notFoundError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newNotFoundError(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newNotFoundError(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new invalidUsernameOrPasswordError error can be created with default message, status and cause', () => {
-    const error = errors.newInvalidUsernameOrPasswordError()
-    expect(error.message).toBe(errors._errors.INVALID_USERNAME_OR_PASSWORD_ERROR.message)
-    expect(error.status).toBe(errors._errors.INVALID_USERNAME_OR_PASSWORD_ERROR.status)
-    expect(error.cause).toEqual(errors._errors.INVALID_USERNAME_OR_PASSWORD_ERROR.cause)
+  const error = errors.newInvalidUsernameOrPasswordError()
+  expect(error.message).toBe(errors._errors.INVALID_USERNAME_OR_PASSWORD_ERROR.message)
+  expect(error.status).toBe(errors._errors.INVALID_USERNAME_OR_PASSWORD_ERROR.status)
+  expect(error.cause).toEqual(errors._errors.INVALID_USERNAME_OR_PASSWORD_ERROR.cause)
 })
 
 test('new invalidUsernameOrPasswordError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newInvalidUsernameOrPasswordError(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newInvalidUsernameOrPasswordError(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new sessionExpiredError error can be created with default message, status and cause', () => {
-    const error = errors.newSessionExpiredError()
-    expect(error.message).toBe(errors._errors.SESSION_EXPIRED_ERROR.message)
-    expect(error.status).toBe(errors._errors.SESSION_EXPIRED_ERROR.status)
-    expect(error.cause).toEqual(errors._errors.SESSION_EXPIRED_ERROR.cause)
+  const error = errors.newSessionExpiredError()
+  expect(error.message).toBe(errors._errors.SESSION_EXPIRED_ERROR.message)
+  expect(error.status).toBe(errors._errors.SESSION_EXPIRED_ERROR.status)
+  expect(error.cause).toEqual(errors._errors.SESSION_EXPIRED_ERROR.cause)
 })
 
 test('new sessionExpiredError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newSessionExpiredError(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newSessionExpiredError(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })
 
 test('new forbiddenResourceError error can be created with default message, status and cause', () => {
-    const error = errors.newForbiddenResourceException()
-    expect(error.message).toBe(errors._errors.FORBIDDEN_RESOURCE_EXCEPTION.message)
-    expect(error.status).toBe(errors._errors.FORBIDDEN_RESOURCE_EXCEPTION.status)
-    expect(error.cause).toEqual(errors._errors.FORBIDDEN_RESOURCE_EXCEPTION.cause)
+  const error = errors.newForbiddenResourceException()
+  expect(error.message).toBe(errors._errors.FORBIDDEN_RESOURCE_EXCEPTION.message)
+  expect(error.status).toBe(errors._errors.FORBIDDEN_RESOURCE_EXCEPTION.status)
+  expect(error.cause).toEqual(errors._errors.FORBIDDEN_RESOURCE_EXCEPTION.cause)
 })
 
 test('new forbiddenResourceError error can be created with custom message, status and cause', () => {
-    const message = 'ERROR'
-    const status = 1000
-    const cause = {}
-    const error = errors.newForbiddenResourceException(message, cause, status)
-    expect(error.message).toBe(message)
-    expect(error.status).toBe(status)
-    expect(error.cause).toEqual(cause)
+  const message = 'ERROR'
+  const status = 1000
+  const cause = {}
+  const error = errors.newForbiddenResourceException(message, cause, status)
+  expect(error.message).toBe(message)
+  expect(error.status).toBe(status)
+  expect(error.cause).toEqual(cause)
 })

--- a/test/unit/utils/utils.spec.js
+++ b/test/unit/utils/utils.spec.js
@@ -1,14 +1,14 @@
 const utils = require('../../../src/utils/utils')
 
 test('logger exists', () => {
-    expect(utils.logger).toBe(utils.logger);
-});
+  expect(utils.logger).toBe(utils.logger)
+})
 
 test('date formats exists and are strings', () => {
-    expect(utils.formats).toHaveProperty('dateTimeFormat')
-    expect(utils.formats).toHaveProperty('dateFormat')
-    expect(utils.formats).toHaveProperty('timeFormat')
-    expect(typeof utils.formats.dateTimeFormat).toBe('string')
-    expect(typeof utils.formats.dateFormat).toBe('string')
-    expect(typeof utils.formats.timeFormat).toBe('string')
+  expect(utils.formats).toHaveProperty('dateTimeFormat')
+  expect(utils.formats).toHaveProperty('dateFormat')
+  expect(utils.formats).toHaveProperty('timeFormat')
+  expect(typeof utils.formats.dateTimeFormat).toBe('string')
+  expect(typeof utils.formats.dateFormat).toBe('string')
+  expect(typeof utils.formats.timeFormat).toBe('string')
 })


### PR DESCRIPTION
## Cambios
- se para el linter y de tener 8000 errores de linter pasamos solo a 300 (que estos se tienen que ver por separado)

- Se recomienda instarlarse el [plugin](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) para vs code asi el ide marca los errores.

- Se agregaron 2 comandos.
`npm run lint` ->  que corre el linter
`npm run lint:fix` ->  corre el linter y fixea los problemas que puede